### PR TITLE
Terrain aspect Wood and entry fixes

### DIFF
--- a/src/assets/minestuck/lang/en_US.lang
+++ b/src/assets/minestuck/lang/en_US.lang
@@ -347,6 +347,9 @@ land.desert=Deserts
 land.sandstone=Sandstone
 land.desertStone=Stony Deserts
 land.shade=Shade
+land.wood=Wood
+land.oak=Oak
+land.lumber=Lumber
 
 land.bucket=Buckets
 land.cake=Cake

--- a/src/assets/minestuck/loot_tables/chests/medium_basic.json
+++ b/src/assets/minestuck/loot_tables/chests/medium_basic.json
@@ -91,6 +91,17 @@
                     "name": "minestuck:chests/medium_basic/shade",
                     "weight": 10
                 },
+                {
+                    "conditions": [
+                        {
+                            "condition": "minestuck:land_aspect",
+                            "land_aspect": "wood"
+                        }
+                    ],
+                    "type": "loot_table",
+                    "name": "minestuck:chests/medium_basic/wood",
+                    "weight": 10
+                },
                 
                 
                 {

--- a/src/assets/minestuck/loot_tables/chests/medium_basic/wood.json
+++ b/src/assets/minestuck/loot_tables/chests/medium_basic/wood.json
@@ -5,108 +5,7 @@
             "rolls": 1,
             "entries": [
                 {
-                    "type": "item",
-                    "name": "minecraft:planks",
-                    "weight": 15,
-                    "quality": -2,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 2,
-                                "max": 16
-                            }
-                        },
-                        {
-                            "function": "set_data",
-                            "data": 3
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "minecraft:log",
-                    "weight": 10,
-                    "quality": -2,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 8
-                            }
-                        },
-                        {
-                            "function": "set_data",
-                            "data": 3
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "minecraft:sapling",
-                    "weight": 4,
-                    "quality": -2,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        },
-                        {
-                            "function": "set_data",
-                            "data": 3
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "minecraft:sapling",
-                    "weight": 4,
-                    "quality": -2,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 4
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "minecraft:log",
-                    "weight": 8,
-                    "quality": -2,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 5
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "minecraft:planks",
-                    "weight": 15,
-                    "quality": -2,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 2,
-                                "max": 16
-                            }
-                        }
-                    ]
-                },
-                {
+                    "entryName": "darkoak_planks",
                     "type": "item",
                     "name": "minecraft:planks",
                     "weight": 10,
@@ -126,25 +25,43 @@
                     ]
                 },
                 {
+                    "entryName": "jungle_planks",
                     "type": "item",
-                    "name": "minecraft:sapling",
-                    "weight": 4,
+                    "name": "minecraft:planks",
+                    "weight": 15,
                     "quality": -2,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
-                                "min": 1,
-                                "max": 2
+                                "min": 2,
+                                "max": 16
                             }
                         },
                         {
                             "function": "set_data",
-                            "data": 5
+                            "data": 3
                         }
                     ]
                 },
                 {
+                    "entryName": "oak_planks",
+                    "type": "item",
+                    "name": "minecraft:planks",
+                    "weight": 15,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 2,
+                                "max": 16
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entryName": "darkoak_logs",
                     "type": "item",
                     "name": "minecraft:log2",
                     "weight": 4,
@@ -160,8 +77,29 @@
                     ]
                 },
                 {
+                    "entryName": "jungle_logs",
                     "type": "item",
-                    "name": "minestuck:log_glowing",
+                    "name": "minecraft:log",
+                    "weight": 10,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 8
+                            }
+                        },
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        }
+                    ]
+                },
+                {
+                    "entryName": "oak_logs",
+                    "type": "item",
+                    "name": "minecraft:log",
                     "weight": 8,
                     "quality": -2,
                     "functions": [
@@ -175,6 +113,79 @@
                     ]
                 },
                 {
+                    "entryName": "darkoak_saplings",
+                    "type": "item",
+                    "name": "minecraft:sapling",
+                    "weight": 4,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        },
+                        {
+                            "function": "set_data",
+                            "data": 5
+                        }
+                    ]
+                },
+                {
+                    "entryName": "jungle_saplings",
+                    "type": "item",
+                    "name": "minecraft:sapling",
+                    "weight": 4,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        },
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        }
+                    ]
+                },
+                {
+                    "entryName": "oak_saplings",
+                    "type": "item",
+                    "name": "minecraft:sapling",
+                    "weight": 4,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 4
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entryName": "glowing_logs",
+                    "type": "item",
+                    "name": "minestuck:glowing_log",
+                    "weight": 8,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 5
+                            }
+                        }
+                    ]
+                },
+                {
+                    "entryName": "iron_ingots",
                     "type": "item",
                     "name": "minecraft:iron_ingot",
                     "weight": 2,
@@ -190,6 +201,7 @@
                     ]
                 },
                 {
+                    "entryName": "redstone",
                     "type": "item",
                     "name": "minecraft:redstone",
                     "weight": 5,
@@ -205,6 +217,7 @@
                     ]
                 },
                 {
+                    "entryName": "pogo_hammer",
                     "type": "item",
                     "name": "minestuck:pogo_hammer",
                     "weight": 3,
@@ -220,6 +233,7 @@
                     ]
                 },
                 {
+                    "entryName": "iron_axe",
                     "type": "item",
                     "name": "minecraft:iron_axe",
                     "weight": 3,

--- a/src/assets/minestuck/loot_tables/chests/medium_basic/wood.json
+++ b/src/assets/minestuck/loot_tables/chests/medium_basic/wood.json
@@ -1,0 +1,240 @@
+{
+    "pools": [
+        {
+            "name": "main",
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:planks",
+                    "weight": 15,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 2,
+                                "max": 16
+                            }
+                        },
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:log",
+                    "weight": 10,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 8
+                            }
+                        },
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:sapling",
+                    "weight": 4,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        },
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:sapling",
+                    "weight": 4,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 4
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:log",
+                    "weight": 8,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 5
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:planks",
+                    "weight": 15,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 2,
+                                "max": 16
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:planks",
+                    "weight": 10,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 8
+                            }
+                        },
+                        {
+                            "function": "set_data",
+                            "data": 5
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:sapling",
+                    "weight": 4,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        },
+                        {
+                            "function": "set_data",
+                            "data": 5
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:log2",
+                    "weight": 4,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 4
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minestuck:log_glowing",
+                    "weight": 8,
+                    "quality": -2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 5
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:iron_ingot",
+                    "weight": 2,
+                    "quality": 2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:redstone",
+                    "weight": 5,
+                    "quality": 0,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 7
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minestuck:pogo_hammer",
+                    "weight": 3,
+                    "quality": 0,
+                    "functions": [
+                        {
+                            "function": "set_damage",
+                            "damage": {
+                                "min": 0.75,
+                                "max": 1
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:iron_axe",
+                    "weight": 3,
+                    "quality": 1,
+                    "functions": [
+                        {
+                            "function": "set_damage",
+                            "damage": {
+                                "min": 0.75,
+                                "max": 1
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/com/mraof/minestuck/client/model/ModelImp.java
+++ b/src/com/mraof/minestuck/client/model/ModelImp.java
@@ -5,6 +5,8 @@
 // - ZeuX
 package com.mraof.minestuck.client.model;
 
+import org.lwjgl.opengl.GL11;
+
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.entity.Entity;
@@ -60,6 +62,9 @@ public class ModelImp extends ModelBase
 	@Override
 	public void render(Entity entity, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch, float scale)
 	{
+		scale*=1.5F;
+		GL11.glTranslatef(0F, -0.6F, 0F);
+		
 		setRotationAngles(limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch, scale, entity);
 		Head.render(scale);
 		Body.render(scale);

--- a/src/com/mraof/minestuck/entity/underling/EntityImp.java
+++ b/src/com/mraof/minestuck/entity/underling/EntityImp.java
@@ -19,7 +19,7 @@ public class EntityImp extends EntityUnderling
 	public EntityImp(World world) 
 	{
 		super(world, "imp");
-		setSize(0.5F, 1.0F);
+		setSize(0.75F, 1.5F);
 	}
 	
 	@Override

--- a/src/com/mraof/minestuck/item/ItemCruxiteArtifact.java
+++ b/src/com/mraof/minestuck/item/ItemCruxiteArtifact.java
@@ -143,6 +143,10 @@ public abstract class ItemCruxiteArtifact extends Item implements Teleport.ITele
 						{
 							copyBlockDirect(chunk, chunk2, blockX & 15, blockY + yDiff, blockY, blockZ & 15);
 						}
+						else
+						{
+							worldserver1.setBlockState(new BlockPos(blockX, blockY + yDiff, blockZ), Blocks.AIR.getDefaultState(), 3);
+						}
 						bl += System.currentTimeMillis() - t;
 						if((te) != null)
 						{
@@ -219,13 +223,13 @@ public abstract class ItemCruxiteArtifact extends Item implements Teleport.ITele
 						if(MinestuckConfig.entryCrater)
 						{
 							if(worldserver0.getBlockState(pos).getBlock() != Blocks.BEDROCK)
-								worldserver0.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
+								worldserver0.setBlockState(pos, Blocks.AIR.getDefaultState(), 3);
 						} else
 						{
 							TileEntity tileEntity = worldserver0.getTileEntity(pos);
 							if(tileEntity != null)
 								if(!creative)
-									worldserver0.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
+									worldserver0.setBlockState(pos, Blocks.AIR.getDefaultState(), 3);
 								else if(tileEntity instanceof TileEntityComputer)	//Avoid duplicating computer data when a computer is kept in the overworld
 									((TileEntityComputer) tileEntity).programData = new NBTTagCompound();
 								else if(tileEntity instanceof TileEntityTransportalizer)

--- a/src/com/mraof/minestuck/item/ItemCruxiteArtifact.java
+++ b/src/com/mraof/minestuck/item/ItemCruxiteArtifact.java
@@ -226,7 +226,7 @@ public abstract class ItemCruxiteArtifact extends Item implements Teleport.ITele
 						{
 							if(worldserver0.getBlockState(pos).getBlock() != Blocks.BEDROCK)
 							{
-								if(isEdgeX || isEdgeZ || blockY == minY || blockY == --maxY)
+								if(isEdgeX || isEdgeZ || blockY == minY || blockY == maxY-1)
 								{
 									worldserver0.setBlockState(pos, Blocks.AIR.getDefaultState(), 3);
 								} else

--- a/src/com/mraof/minestuck/item/ItemCruxiteArtifact.java
+++ b/src/com/mraof/minestuck/item/ItemCruxiteArtifact.java
@@ -217,13 +217,27 @@ public abstract class ItemCruxiteArtifact extends Item implements Teleport.ITele
 					int minY =  y - height;
 					minY = minY < 0 ? 0 : minY;
 					int maxY = MinestuckConfig.entryCrater ? Math.min(topY, y + height) + 1 : 256;
+					
+					//Meant to indicate if this block is on the outer edge of the moved region.
+					//boolean isEdge = true;	//Slow, with block updates.
+					boolean isEdge = Math.abs(radius-artifactRange)<1.0;	//Attempt at balance.
+					//boolean isEdge = false;	//Fast, without block updates.
+					
 					for(int blockY = minY; blockY < maxY; blockY++)
 					{
 						BlockPos pos = new BlockPos(blockX, blockY, blockZ);
 						if(MinestuckConfig.entryCrater)
 						{
 							if(worldserver0.getBlockState(pos).getBlock() != Blocks.BEDROCK)
-								worldserver0.setBlockState(pos, Blocks.AIR.getDefaultState(), 3);
+							{
+								if(isEdge || blockY == minY || blockY == maxY - 1)
+								{
+									worldserver0.setBlockState(pos, Blocks.AIR.getDefaultState(), 3);
+								} else
+								{
+									worldserver0.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
+								}
+							}
 						} else
 						{
 							TileEntity tileEntity = worldserver0.getTileEntity(pos);

--- a/src/com/mraof/minestuck/item/ItemCruxiteArtifact.java
+++ b/src/com/mraof/minestuck/item/ItemCruxiteArtifact.java
@@ -210,6 +210,7 @@ public abstract class ItemCruxiteArtifact extends Item implements Teleport.ITele
 			for(int blockX = x - artifactRange; blockX <= x + artifactRange; blockX++)
 			{
 				int zWidth = (int) Math.sqrt(artifactRange * artifactRange - (blockX - x) * (blockX - x));
+				boolean isEdgeX = Math.abs(blockX-x)==artifactRange;
 				for(int blockZ = z - zWidth; blockZ <= z + zWidth; blockZ++)
 				{
 					double radius = Math.sqrt(((blockX - x) * (blockX - x) + (blockZ - z) * (blockZ - z)) / 2);
@@ -217,12 +218,7 @@ public abstract class ItemCruxiteArtifact extends Item implements Teleport.ITele
 					int minY =  y - height;
 					minY = minY < 0 ? 0 : minY;
 					int maxY = MinestuckConfig.entryCrater ? Math.min(topY, y + height) + 1 : 256;
-					
-					//Meant to indicate if this block is on the outer edge of the moved region.
-					//boolean isEdge = true;	//Slow, with block updates.
-					boolean isEdge = Math.abs(radius-artifactRange)<1.0;	//Attempt at balance.
-					//boolean isEdge = false;	//Fast, without block updates.
-					
+					boolean isEdgeZ = Math.abs(blockZ-z)==zWidth;
 					for(int blockY = minY; blockY < maxY; blockY++)
 					{
 						BlockPos pos = new BlockPos(blockX, blockY, blockZ);
@@ -230,7 +226,7 @@ public abstract class ItemCruxiteArtifact extends Item implements Teleport.ITele
 						{
 							if(worldserver0.getBlockState(pos).getBlock() != Blocks.BEDROCK)
 							{
-								if(isEdge || blockY == minY || blockY == maxY - 1)
+								if(isEdgeX || isEdgeZ || blockY == minY || blockY == --maxY)
 								{
 									worldserver0.setBlockState(pos, Blocks.AIR.getDefaultState(), 3);
 								} else

--- a/src/com/mraof/minestuck/util/Teleport.java
+++ b/src/com/mraof/minestuck/util/Teleport.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
+import net.minecraft.entity.item.*;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.play.server.SPacketEntityEffect;
@@ -97,29 +98,27 @@ public class Teleport
 			Entity newEntity = EntityList.createEntityByName(EntityList.getEntityString(entity), worldDest);
 			if(newEntity == null)
 				return false;
-			
+
+			NBTTagCompound nbt = new NBTTagCompound();
 			entity.dimension = destinationDimension;
+			entity.writeToNBT(nbt);
 			
-			entity.world.removeEntity(entity);
-			entity.isDead = false;
-			
-			entity.setPosition(x, y, z);
 			if(teleporter != null)
 				teleporter.makeDestination(entity, worldFrom, worldDest);
 			worldDest.updateEntityWithOptionalForce(entity, false);
 			
-			NBTTagCompound nbt = new NBTTagCompound();
-			entity.writeToNBT(nbt);
 			nbt.removeTag("Dimension");
 			newEntity.readFromNBT(nbt);
 			newEntity.timeUntilPortal = entity.timeUntilPortal;
-			
+			newEntity.setPosition(x, y, z);
+						
 			boolean flag = newEntity.forceSpawn;
 			newEntity.forceSpawn = true;
 			worldDest.spawnEntity(newEntity);
 			newEntity.forceSpawn = flag;
 			worldDest.updateEntityWithOptionalForce(newEntity, false);
 			
+			entity.world.removeEntity(entity);
 			entity.isDead = true;
 			worldFrom.resetUpdateEntityTick();
 			worldDest.resetUpdateEntityTick();

--- a/src/com/mraof/minestuck/world/lands/LandAspectRegistry.java
+++ b/src/com/mraof/minestuck/world/lands/LandAspectRegistry.java
@@ -43,6 +43,7 @@ public class LandAspectRegistry
 		registerLandAspect(new LandAspectSandstone());
 		registerLandAspect(new LandAspectForest());
 		registerLandAspect(new LandAspectRock());
+		registerLandAspect(new LandAspectWood());
 		
 		registerLandAspect(new LandAspectWind(), EnumAspect.BREATH);
 		registerLandAspect(new LandAspectLight(), EnumAspect.LIGHT);

--- a/src/com/mraof/minestuck/world/lands/terrain/LandAspectWood.java
+++ b/src/com/mraof/minestuck/world/lands/terrain/LandAspectWood.java
@@ -13,6 +13,9 @@ import com.mraof.minestuck.world.lands.decorator.UndergroundDecoratorVein;
 import com.mraof.minestuck.world.lands.structure.blocks.StructureBlockRegistry;
 
 import net.minecraft.block.BlockLog;
+import net.minecraft.block.BlockNewLog;
+import net.minecraft.block.BlockOldLog;
+import net.minecraft.block.BlockPlanks;
 import net.minecraft.block.BlockStoneBrick;
 import net.minecraft.block.BlockTorch;
 import net.minecraft.init.Blocks;
@@ -30,11 +33,11 @@ public class LandAspectWood extends TerrainLandAspect
 		registry.setBlockState("surface", Blocks.PLANKS.getDefaultState());
 		registry.setBlockState("ocean", Blocks.WATER.getDefaultState());
 		registry.setBlockState("river", Blocks.WATER.getDefaultState());
-		registry.setBlockState("structure_primary", Blocks.LOG.getStateFromMeta(3));
-		registry.setBlockState("structure_primary_decorative", Blocks.LOG2.getStateFromMeta(1));
+		registry.setBlockState("structure_primary", Blocks.LOG.getDefaultState().withProperty(BlockOldLog.VARIANT, BlockPlanks.EnumType.JUNGLE));
+		registry.setBlockState("structure_primary_decorative", Blocks.LOG2.getDefaultState().withProperty(BlockNewLog.VARIANT, BlockPlanks.EnumType.DARK_OAK));
 		registry.setBlockState("structure_primary_stairs", Blocks.DARK_OAK_STAIRS.getDefaultState());
-		registry.setBlockState("structure_secondary", Blocks.PLANKS.getStateFromMeta(3));
-		registry.setBlockState("structure_secondary_decorative", Blocks.PLANKS.getStateFromMeta(5));
+		registry.setBlockState("structure_secondary", Blocks.PLANKS.getDefaultState().withProperty(BlockPlanks.VARIANT, BlockPlanks.EnumType.JUNGLE));
+		registry.setBlockState("structure_secondary_decorative", Blocks.PLANKS.getDefaultState().withProperty(BlockPlanks.VARIANT, BlockPlanks.EnumType.DARK_OAK));
 		registry.setBlockState("structure_secondary_stairs", Blocks.JUNGLE_STAIRS.getDefaultState());
 		registry.setBlockState("fall_fluid", Blocks.WATER.getDefaultState());
 		registry.setBlockState("light_block", MinestuckBlocks.glowingLog.getDefaultState());

--- a/src/com/mraof/minestuck/world/lands/terrain/LandAspectWood.java
+++ b/src/com/mraof/minestuck/world/lands/terrain/LandAspectWood.java
@@ -33,14 +33,14 @@ public class LandAspectWood extends TerrainLandAspect
 		registry.setBlockState("surface", Blocks.PLANKS.getDefaultState());
 		registry.setBlockState("ocean", Blocks.WATER.getDefaultState());
 		registry.setBlockState("river", Blocks.WATER.getDefaultState());
-		registry.setBlockState("structure_primary", Blocks.LOG.getDefaultState().withProperty(BlockOldLog.VARIANT, BlockPlanks.EnumType.JUNGLE));
+		registry.setBlockState("structure_primary", Blocks.LOG.getDefaultState().withProperty(BlockOldLog.VARIANT, BlockPlanks.EnumType.JUNGLE).withProperty(BlockLog.LOG_AXIS, BlockLog.EnumAxis.NONE));
 		registry.setBlockState("structure_primary_decorative", Blocks.LOG2.getDefaultState().withProperty(BlockNewLog.VARIANT, BlockPlanks.EnumType.DARK_OAK));
 		registry.setBlockState("structure_primary_stairs", Blocks.DARK_OAK_STAIRS.getDefaultState());
 		registry.setBlockState("structure_secondary", Blocks.PLANKS.getDefaultState().withProperty(BlockPlanks.VARIANT, BlockPlanks.EnumType.JUNGLE));
 		registry.setBlockState("structure_secondary_decorative", Blocks.PLANKS.getDefaultState().withProperty(BlockPlanks.VARIANT, BlockPlanks.EnumType.DARK_OAK));
 		registry.setBlockState("structure_secondary_stairs", Blocks.JUNGLE_STAIRS.getDefaultState());
 		registry.setBlockState("fall_fluid", Blocks.WATER.getDefaultState());
-		registry.setBlockState("light_block", MinestuckBlocks.glowingLog.getDefaultState());
+		registry.setBlockState("light_block", MinestuckBlocks.glowingLog.getDefaultState().withProperty(BlockLog.LOG_AXIS, BlockLog.EnumAxis.NONE));
 	}
 	
 	@Override
@@ -59,13 +59,13 @@ public class LandAspectWood extends TerrainLandAspect
 	{
 		ArrayList<ILandDecorator> list = new ArrayList<ILandDecorator>();
 		list.add(new SurfaceDecoratorVein(Blocks.LEAVES.getDefaultState(), 15, 32, BiomeMinestuck.mediumRough));
-		list.add(new SurfaceDecoratorVein(MinestuckBlocks.log.getDefaultState(), 8, 32, BiomeMinestuck.mediumNormal));
-		list.add(new SurfaceDecoratorVein(Blocks.NETHERRACK.getDefaultState(), 5, 8, BiomeMinestuck.mediumNormal));
+		list.add(new SurfaceDecoratorVein(MinestuckBlocks.log.getDefaultState().withProperty(BlockLog.LOG_AXIS, BlockLog.EnumAxis.NONE), 8, 32, BiomeMinestuck.mediumNormal));
+		list.add(new SurfaceDecoratorVein(Blocks.NETHERRACK.getDefaultState(), 6, 8, BiomeMinestuck.mediumNormal));
 		
 		list.add(new UndergroundDecoratorVein(Blocks.GRAVEL.getDefaultState(), 8, 33, 256));
-		list.add(new UndergroundDecoratorVein(Blocks.DIRT.getDefaultState(), 26, 17, 128));
-		list.add(new UndergroundDecoratorVein(Blocks.REDSTONE_ORE.getDefaultState(), 4, 7, 32));
-		list.add(new UndergroundDecoratorVein(Blocks.IRON_ORE.getDefaultState(), 4, 9, 32));
+		list.add(new UndergroundDecoratorVein(Blocks.DIRT.getDefaultState(), 18, 17, 128));
+		list.add(new UndergroundDecoratorVein(Blocks.REDSTONE_ORE.getDefaultState(), 8, 7, 32));
+		list.add(new UndergroundDecoratorVein(Blocks.IRON_ORE.getDefaultState(), 12, 9, 32));
 		list.add(new UndergroundDecoratorVein(Blocks.EMERALD_ORE.getDefaultState(), 8, 3, 24));
 		return list;
 	}

--- a/src/com/mraof/minestuck/world/lands/terrain/LandAspectWood.java
+++ b/src/com/mraof/minestuck/world/lands/terrain/LandAspectWood.java
@@ -1,0 +1,87 @@
+package com.mraof.minestuck.world.lands.terrain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.mraof.minestuck.block.BlockMinestuckStone;
+import com.mraof.minestuck.block.MinestuckBlocks;
+import com.mraof.minestuck.world.biome.BiomeMinestuck;
+import com.mraof.minestuck.world.lands.decorator.FireFieldDecorator;
+import com.mraof.minestuck.world.lands.decorator.ILandDecorator;
+import com.mraof.minestuck.world.lands.decorator.SurfaceDecoratorVein;
+import com.mraof.minestuck.world.lands.decorator.UndergroundDecoratorVein;
+import com.mraof.minestuck.world.lands.structure.blocks.StructureBlockRegistry;
+
+import net.minecraft.block.BlockLog;
+import net.minecraft.block.BlockStoneBrick;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.math.Vec3d;
+
+public class LandAspectWood extends TerrainLandAspect 
+{
+	static Vec3d skyColor = new Vec3d(0.0D, 0.16D, 0.38D);
+	
+	@Override
+	public void registerBlocks(StructureBlockRegistry registry)
+	{
+		registry.setBlockState("surface", Blocks.PLANKS.getDefaultState());
+		registry.setBlockState("upper", Blocks.LOG.getDefaultState());
+		registry.setBlockState("ocean", Blocks.WATER.getDefaultState());
+		registry.setBlockState("structure_primary", Blocks.LOG.getDefaultState());
+		registry.setBlockState("structure_primary_decorative", MinestuckBlocks.glowingLog.getDefaultState().withProperty(BlockLog.LOG_AXIS, BlockLog.EnumAxis.NONE));
+		registry.setBlockState("structure_primary_stairs", Blocks.OAK_STAIRS.getDefaultState());
+		registry.setBlockState("fall_fluid", Blocks.WATER.getDefaultState());
+	}
+	
+	@Override
+	public String getPrimaryName()
+	{
+		return "wood";
+	}
+
+	@Override
+	public String[] getNames() {
+		return new String[] {"wood","oak","lumber"};
+	}
+	
+	@Override
+	public List<ILandDecorator> getDecorators()
+	{
+		ArrayList<ILandDecorator> list = new ArrayList<ILandDecorator>();
+		list.add(new SurfaceDecoratorVein(Blocks.LEAVES.getDefaultState(), 15, 32, BiomeMinestuck.mediumRough));
+		list.add(new SurfaceDecoratorVein(Blocks.OAK_FENCE.getDefaultState(), 8, 32, BiomeMinestuck.mediumNormal));
+		list.add(new SurfaceDecoratorVein(Blocks.NETHERRACK.getDefaultState(), 5, 8, BiomeMinestuck.mediumNormal));
+		
+		list.add(new UndergroundDecoratorVein(Blocks.GRAVEL.getDefaultState(), 8, 33, 256));
+		list.add(new UndergroundDecoratorVein(Blocks.DIRT.getDefaultState(), 26, 17, 128));
+		list.add(new UndergroundDecoratorVein(Blocks.REDSTONE_ORE.getDefaultState(), 4, 7, 32));
+		list.add(new UndergroundDecoratorVein(Blocks.IRON_ORE.getDefaultState(), 4, 9, 32));
+		list.add(new UndergroundDecoratorVein(Blocks.EMERALD_ORE.getDefaultState(), 8, 3, 24));
+		return list;
+	}
+	
+	@Override
+	public int getDayCycleMode()
+	{
+		return 2;
+	}
+	
+	@Override
+	public Vec3d getFogColor() 
+	{
+		return skyColor;
+	}
+	
+	@Override
+	public float getTemperature()
+	{
+		return 1.0F;
+	}
+	
+	@Override
+	public float getRainfall()
+	{
+		return 0.5F;
+	}
+	
+}

--- a/src/com/mraof/minestuck/world/lands/terrain/LandAspectWood.java
+++ b/src/com/mraof/minestuck/world/lands/terrain/LandAspectWood.java
@@ -14,6 +14,7 @@ import com.mraof.minestuck.world.lands.structure.blocks.StructureBlockRegistry;
 
 import net.minecraft.block.BlockLog;
 import net.minecraft.block.BlockStoneBrick;
+import net.minecraft.block.BlockTorch;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.math.Vec3d;
 
@@ -24,13 +25,19 @@ public class LandAspectWood extends TerrainLandAspect
 	@Override
 	public void registerBlocks(StructureBlockRegistry registry)
 	{
-		registry.setBlockState("surface", Blocks.PLANKS.getDefaultState());
+		registry.setBlockState("ground", Blocks.STONE.getDefaultState());
 		registry.setBlockState("upper", Blocks.LOG.getDefaultState());
+		registry.setBlockState("surface", Blocks.PLANKS.getDefaultState());
 		registry.setBlockState("ocean", Blocks.WATER.getDefaultState());
-		registry.setBlockState("structure_primary", Blocks.LOG.getDefaultState());
-		registry.setBlockState("structure_primary_decorative", MinestuckBlocks.glowingLog.getDefaultState().withProperty(BlockLog.LOG_AXIS, BlockLog.EnumAxis.NONE));
-		registry.setBlockState("structure_primary_stairs", Blocks.OAK_STAIRS.getDefaultState());
+		registry.setBlockState("river", Blocks.WATER.getDefaultState());
+		registry.setBlockState("structure_primary", Blocks.LOG.getStateFromMeta(3));
+		registry.setBlockState("structure_primary_decorative", Blocks.LOG2.getStateFromMeta(1));
+		registry.setBlockState("structure_primary_stairs", Blocks.DARK_OAK_STAIRS.getDefaultState());
+		registry.setBlockState("structure_secondary", Blocks.PLANKS.getStateFromMeta(3));
+		registry.setBlockState("structure_secondary_decorative", Blocks.PLANKS.getStateFromMeta(5));
+		registry.setBlockState("structure_secondary_stairs", Blocks.JUNGLE_STAIRS.getDefaultState());
 		registry.setBlockState("fall_fluid", Blocks.WATER.getDefaultState());
+		registry.setBlockState("light_block", MinestuckBlocks.glowingLog.getDefaultState());
 	}
 	
 	@Override
@@ -49,7 +56,7 @@ public class LandAspectWood extends TerrainLandAspect
 	{
 		ArrayList<ILandDecorator> list = new ArrayList<ILandDecorator>();
 		list.add(new SurfaceDecoratorVein(Blocks.LEAVES.getDefaultState(), 15, 32, BiomeMinestuck.mediumRough));
-		list.add(new SurfaceDecoratorVein(Blocks.OAK_FENCE.getDefaultState(), 8, 32, BiomeMinestuck.mediumNormal));
+		list.add(new SurfaceDecoratorVein(MinestuckBlocks.log.getDefaultState(), 8, 32, BiomeMinestuck.mediumNormal));
 		list.add(new SurfaceDecoratorVein(Blocks.NETHERRACK.getDefaultState(), 5, 8, BiomeMinestuck.mediumNormal));
 		
 		list.add(new UndergroundDecoratorVein(Blocks.GRAVEL.getDefaultState(), 8, 33, 256));
@@ -81,7 +88,7 @@ public class LandAspectWood extends TerrainLandAspect
 	@Override
 	public float getRainfall()
 	{
-		return 0.5F;
+		return 0.6F;
 	}
 	
 }


### PR DESCRIPTION
I just figured out how to do pull requests, though I've already got two un-pulled commits here.

The first commit creates the terrain aspect Wood. It's a new terrain aspect meant to serve as the second home for salamanders in the consort update, thereby providing an even distribution of consorts.

The second commit serves to fix a few glitches with entry. Without these fixes, there would be several block updates that should occur and would not, and any entity that changes its information when it is removed from the world would enter with the post-removal data (thus far, I only know of this emptying minecart containers such as minecart chests and minecart hoppers, but other such entities may exist).

As with all pull requests, look it over and let me know how it is.