### PR TITLE
Add /classes to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /src/main/generated/resources/.cache/
 /.metadata
 /logs/
+/classes


### PR DESCRIPTION
I have about 3000 unversioned files reported by git in the `/classes` directory that are generated by the build process. They really don't need to be able to be included afaik.