### PR TITLE
Tiered Dungeons

### DIFF
--- a/src/main/generated/resources/assets/minestuck/lang/en_us.json
+++ b/src/main/generated/resources/assets/minestuck/lang/en_us.json
@@ -292,7 +292,7 @@
   "block.minestuck.mini_typheus_statue": "Small Denizen Statue",
   "block.minestuck.mini_wizard_statue": "Small Wizard Statue",
   "block.minestuck.mossy_chalk_bricks": "Mossy Chalk Bricks",
-  "block.minestuck.mossy_coarse_stone": "Mossy Coarse Stone",
+  "block.minestuck.mossy_coarse_stone": "Mossy Coarse Stone Bricks",
   "block.minestuck.mossy_decrepit_stone_bricks": "Mossy Decrepit Stone Bricks",
   "block.minestuck.mossy_mycelium_bricks": "Mossy Mycelium Bricks",
   "block.minestuck.mossy_pink_stone_bricks": "Mossy Pink Stone Bricks",

--- a/src/main/java/com/mraof/minestuck/block/MSBlocks.java
+++ b/src/main/java/com/mraof/minestuck/block/MSBlocks.java
@@ -76,7 +76,7 @@ public class MSBlocks
 	
 	//Land Environment Blocks
 	public static final Block BLUE_DIRT = getNull(), THOUGHT_DIRT = getNull();
-	public static final Block COARSE_STONE = getNull(), CHISELED_COARSE_STONE = getNull(), COARSE_STONE_BRICKS = getNull(), COARSE_STONE_COLUMN = getNull(), CHISELED_COARSE_STONE_BRICKS = getNull(), CRACKED_COARSE_STONE_BRICKS = getNull(), MOSSY_COARSE_STONE = getNull();
+	public static final Block COARSE_STONE = getNull(), CHISELED_COARSE_STONE = getNull(), COARSE_STONE_BRICKS = getNull(), COARSE_STONE_COLUMN = getNull(), CHISELED_COARSE_STONE_BRICKS = getNull(), CRACKED_COARSE_STONE_BRICKS = getNull(),/*TODO Rename this blocks registry to be MOSSY_COARSE_STONE_BRICKS when 1.18 rolls around*/ MOSSY_COARSE_STONE = getNull();
 	public static final Block SHADE_STONE = getNull(), SMOOTH_SHADE_STONE = getNull(), SHADE_BRICKS = getNull(), SHADE_COLUMN = getNull(), CHISELED_SHADE_BRICKS = getNull(), CRACKED_SHADE_BRICKS = getNull(), MOSSY_SHADE_BRICKS = getNull(), BLOOD_SHADE_BRICKS = getNull(), TAR_SHADE_BRICKS = getNull();
 	public static final Block FROST_BRICKS = getNull(), FROST_TILE = getNull(), CHISELED_FROST_TILE = getNull(), FROST_COLUMN = getNull(),  CHISELED_FROST_BRICKS = getNull(), CRACKED_FROST_BRICKS = getNull(), FLOWERY_FROST_BRICKS = getNull();
 	public static final Block CAST_IRON = getNull(), CHISELED_CAST_IRON = getNull();

--- a/src/main/java/com/mraof/minestuck/data/MinestuckEnUsLanguageProvider.java
+++ b/src/main/java/com/mraof/minestuck/data/MinestuckEnUsLanguageProvider.java
@@ -129,7 +129,7 @@ public class MinestuckEnUsLanguageProvider extends MinestuckLanguageProvider
 		add(MSBlocks.COARSE_STONE_COLUMN, "Coarse Stone Column");
 		add(MSBlocks.CHISELED_COARSE_STONE_BRICKS, "Chiseled Coarse Stone Bricks");
 		add(MSBlocks.CRACKED_COARSE_STONE_BRICKS, "Cracked Coarse Stone Bricks");
-		add(MSBlocks.MOSSY_COARSE_STONE, "Mossy Coarse Stone");
+		add(MSBlocks.MOSSY_COARSE_STONE, "Mossy Coarse Stone Bricks");
 		add(MSBlocks.SHADE_STONE, "Shade Stone");
 		add(MSBlocks.SMOOTH_SHADE_STONE, "Smooth Shade Stone");
 		add(MSBlocks.SHADE_BRICKS, "Shade Bricks");

--- a/src/main/java/com/mraof/minestuck/world/gen/feature/MSFillerBlockTypes.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/feature/MSFillerBlockTypes.java
@@ -12,6 +12,7 @@ public class MSFillerBlockTypes
 	public static final RuleTest COARSE_END_STONE = new BlockMatchRuleTest(MSBlocks.COARSE_END_STONE);
 	public static final RuleTest SHADE_STONE = new BlockMatchRuleTest(MSBlocks.SHADE_STONE);
 	public static final RuleTest PINK_STONE = new BlockMatchRuleTest(MSBlocks.PINK_STONE);
+	public static final RuleTest MYCELIUM_STONE = new BlockMatchRuleTest(MSBlocks.MYCELIUM_STONE);
 	
 	public static void init()
 	{

--- a/src/main/java/com/mraof/minestuck/world/gen/feature/structure/blocks/StructureBlockRegistry.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/feature/structure/blocks/StructureBlockRegistry.java
@@ -83,6 +83,9 @@ public final class StructureBlockRegistry
 		registerBlock("sand", Blocks.SAND.defaultBlockState());
 		registerBlock("structure_primary", Blocks.STONE_BRICKS.defaultBlockState());
 		registerBlock("structure_primary_decorative", "structure_primary", Blocks.CHISELED_STONE_BRICKS);
+		registerBlock("structure_primary_cracked", "structure_primary", Blocks.CRACKED_STONE_BRICKS);
+		registerBlock("structure_primary_mossy", "structure_primary", Blocks.MOSSY_STONE_BRICKS);
+		registerBlock("structure_primary_column", "structure_primary", MSBlocks.COARSE_STONE_COLUMN);
 		registerBlock("structure_primary_stairs", "structure_primary", Blocks.STONE_BRICK_STAIRS);
 		registerBlock("structure_secondary", "structure_primary", Blocks.NETHER_BRICKS);
 		registerBlock("structure_secondary_decorative", "structure_secondary", Blocks.RED_NETHER_BRICKS);

--- a/src/main/java/com/mraof/minestuck/world/lands/terrain/FloraLandType.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/terrain/FloraLandType.java
@@ -45,9 +45,10 @@ public class FloraLandType extends TerrainLandType
 		registry.setBlockState("surface_rough", Blocks.COARSE_DIRT.defaultBlockState());
 		registry.setBlockState("upper", Blocks.DIRT.defaultBlockState());
 		registry.setBlockState("ocean", MSBlocks.BLOOD.defaultBlockState());
-		registry.setBlockState("structure_primary", Blocks.MOSSY_STONE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary", MSBlocks.MOSSY_DECREPIT_STONE_BRICKS.defaultBlockState());
 		registry.setBlockState("structure_primary_decorative", MSBlocks.FLOWERY_MOSSY_STONE_BRICKS.defaultBlockState());
-		registry.setBlockState("structure_secondary_stairs", Blocks.STONE_BRICK_STAIRS.defaultBlockState());
+		registry.setBlockState("structure_primary_mossy", MSBlocks.MOSSY_DECREPIT_STONE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_stairs", Blocks.STONE_BRICK_STAIRS.defaultBlockState());
 		registry.setBlockState("structure_secondary", Blocks.MOSSY_COBBLESTONE.defaultBlockState());
 		registry.setBlockState("structure_secondary_decorative", MSBlocks.FLOWERY_MOSSY_COBBLESTONE.defaultBlockState());
 		registry.setBlockState("structure_secondary_stairs", Blocks.DARK_OAK_STAIRS.defaultBlockState());

--- a/src/main/java/com/mraof/minestuck/world/lands/terrain/FrostLandType.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/terrain/FrostLandType.java
@@ -41,8 +41,11 @@ public class FrostLandType extends TerrainLandType
 	{
 		registry.setBlockState("surface", Blocks.GRASS_BLOCK.defaultBlockState());
 		registry.setBlockState("upper", Blocks.DIRT.defaultBlockState());
-		registry.setBlockState("structure_primary", Blocks.PRISMARINE.defaultBlockState());
-		registry.setBlockState("structure_primary_decorative", Blocks.PRISMARINE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary", MSBlocks.FROST_TILE.defaultBlockState());
+		registry.setBlockState("structure_primary_decorative", MSBlocks.CHISELED_FROST_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_cracked", MSBlocks.CRACKED_FROST_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_column", MSBlocks.FROST_COLUMN.defaultBlockState());
+		registry.setBlockState("structure_primary_stairs", MSBlocks.FROST_TILE_STAIRS.defaultBlockState());
 		registry.setBlockState("structure_secondary", MSBlocks.FROST_BRICKS.defaultBlockState());
 		registry.setBlockState("structure_secondary_stairs", MSBlocks.FROST_BRICK_STAIRS.defaultBlockState());
 		registry.setBlockState("structure_secondary_decorative", MSBlocks.CHISELED_FROST_BRICKS.defaultBlockState());

--- a/src/main/java/com/mraof/minestuck/world/lands/terrain/FungiLandType.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/terrain/FungiLandType.java
@@ -7,6 +7,7 @@ import com.mraof.minestuck.entity.consort.ConsortEntity;
 import com.mraof.minestuck.util.MSSoundEvents;
 import com.mraof.minestuck.world.biome.LandBiomeType;
 import com.mraof.minestuck.world.gen.LandGenSettings;
+import com.mraof.minestuck.world.gen.feature.MSFillerBlockTypes;
 import com.mraof.minestuck.world.gen.feature.structure.GateMushroomPiece;
 import com.mraof.minestuck.world.gen.feature.structure.blocks.StructureBlockRegistry;
 import com.mraof.minestuck.world.lands.LandProperties;
@@ -41,14 +42,19 @@ public class FungiLandType extends TerrainLandType
 	@Override
 	public void registerBlocks(StructureBlockRegistry registry)
 	{
+		registry.setGroundState(MSBlocks.MYCELIUM_STONE.defaultBlockState(), MSFillerBlockTypes.MYCELIUM_STONE);
 		registry.setBlockState("surface", Blocks.MYCELIUM.defaultBlockState());
 		registry.setBlockState("upper", Blocks.DIRT.defaultBlockState());
 		registry.setBlockState("ocean", Blocks.WATER.defaultBlockState());
-		registry.setBlockState("structure_primary_decorative", Blocks.MOSSY_STONE_BRICKS.defaultBlockState());
-		registry.setBlockState("structure_primary_stairs", Blocks.STONE_BRICK_STAIRS.defaultBlockState());
-		registry.setBlockState("structure_secondary", MSBlocks.MYCELIUM_BRICKS.defaultBlockState());
-		registry.setBlockState("structure_secondary_decorative", Blocks.CHISELED_STONE_BRICKS.defaultBlockState());
-		registry.setBlockState("structure_secondary_stairs", MSBlocks.MYCELIUM_BRICK_STAIRS.defaultBlockState());
+		registry.setBlockState("structure_primary", MSBlocks.MYCELIUM_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_decorative", MSBlocks.CHISELED_MYCELIUM_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_cracked", MSBlocks.CRACKED_MYCELIUM_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_mossy", MSBlocks.MOSSY_MYCELIUM_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_column", MSBlocks.MYCELIUM_COLUMN.defaultBlockState());
+		registry.setBlockState("structure_primary_stairs", MSBlocks.MYCELIUM_BRICK_STAIRS.defaultBlockState());
+		registry.setBlockState("structure_secondary", MSBlocks.POLISHED_MYCELIUM_STONE.defaultBlockState());
+		registry.setBlockState("structure_secondary_decorative", MSBlocks.MYCELIUM_COBBLESTONE.defaultBlockState());
+		registry.setBlockState("structure_secondary_stairs", MSBlocks.MYCELIUM_STAIRS.defaultBlockState());
 		registry.setBlockState("village_path", Blocks.GRASS_PATH.defaultBlockState());
 		registry.setBlockState("light_block", MSBlocks.GLOWY_GOOP.defaultBlockState());
 		registry.setBlockState("torch", Blocks.REDSTONE_TORCH.defaultBlockState());

--- a/src/main/java/com/mraof/minestuck/world/lands/terrain/HeatLandType.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/terrain/HeatLandType.java
@@ -39,10 +39,13 @@ public class HeatLandType extends TerrainLandType
 	public void registerBlocks(StructureBlockRegistry registry)
 	{
 		registry.setGroundState(Blocks.NETHERRACK.defaultBlockState(), OreFeatureConfig.FillerBlockType.NETHER_ORE_REPLACEABLES);
-		registry.setBlockState("upper", MSBlocks.BLACK_STONE.defaultBlockState());
+		registry.setBlockState("upper", Blocks.NETHERRACK.defaultBlockState());
 		registry.setBlockState("ocean", Blocks.LAVA.defaultBlockState());
-		registry.setBlockState("structure_primary", Blocks.NETHER_BRICKS.defaultBlockState());
-		registry.setBlockState("structure_primary_stairs", Blocks.NETHER_BRICK_STAIRS.defaultBlockState());
+		registry.setBlockState("structure_primary", MSBlocks.BLACK_STONE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_decorative", MSBlocks.CHISELED_BLACK_STONE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_cracked", MSBlocks.CRACKED_BLACK_STONE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_column", MSBlocks.BLACK_STONE_COLUMN.defaultBlockState());
+		registry.setBlockState("structure_primary_stairs", MSBlocks.BLACK_STONE_BRICK_STAIRS.defaultBlockState());
 		registry.setBlockState("structure_secondary", MSBlocks.CAST_IRON.defaultBlockState());
 		registry.setBlockState("structure_secondary_decorative", MSBlocks.CHISELED_CAST_IRON.defaultBlockState());
 		registry.setBlockState("structure_secondary_stairs", MSBlocks.CAST_IRON_STAIRS.defaultBlockState());

--- a/src/main/java/com/mraof/minestuck/world/lands/terrain/RainLandType.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/terrain/RainLandType.java
@@ -54,8 +54,11 @@ public class RainLandType extends TerrainLandType
 		registry.setBlockState("upper", MSBlocks.CHALK.defaultBlockState());
 		registry.setBlockState("ocean", Blocks.WATER.defaultBlockState());
 		registry.setBlockState("structure_primary", MSBlocks.PINK_STONE_BRICKS.defaultBlockState());
-		registry.setBlockState("structure_primary_stairs", MSBlocks.PINK_STONE_BRICK_STAIRS.defaultBlockState());
+		registry.setBlockState("structure_primary_cracked", MSBlocks.CRACKED_PINK_STONE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_mossy", MSBlocks.MOSSY_PINK_STONE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_column", MSBlocks.PINK_STONE_COLUMN.defaultBlockState());
 		registry.setBlockState("structure_primary_decorative", MSBlocks.CHISELED_PINK_STONE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_stairs",MSBlocks.PINK_STONE_BRICK_STAIRS.defaultBlockState());
 		registry.setBlockState("structure_secondary", MSBlocks.POLISHED_PINK_STONE.defaultBlockState());
 		registry.setBlockState("structure_secondary_stairs", MSBlocks.CHALK_BRICK_STAIRS.defaultBlockState());
 		registry.setBlockState("structure_secondary_decorative", MSBlocks.CHISELED_PINK_STONE_BRICKS.defaultBlockState());

--- a/src/main/java/com/mraof/minestuck/world/lands/terrain/RockLandType.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/terrain/RockLandType.java
@@ -57,8 +57,9 @@ public class RockLandType extends TerrainLandType
 		}
 		
 		registry.setBlockState("upper", Blocks.COBBLESTONE.defaultBlockState());
-		registry.setBlockState("structure_primary_decorative", Blocks.CHISELED_STONE_BRICKS.defaultBlockState());
-		registry.setBlockState("structure_primary_stairs", Blocks.STONE_BRICK_STAIRS.defaultBlockState());
+		registry.setBlockState("structure_primary", MSBlocks.COARSE_STONE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_decorative", MSBlocks.CHISELED_COARSE_STONE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_stairs", MSBlocks.COARSE_STONE_BRICK_STAIRS.defaultBlockState());
 		registry.setBlockState("structure_secondary", MSBlocks.COARSE_STONE.defaultBlockState());
 		registry.setBlockState("structure_secondary_decorative", MSBlocks.CHISELED_COARSE_STONE.defaultBlockState());
 		registry.setBlockState("structure_secondary_stairs", MSBlocks.COARSE_STONE_STAIRS.defaultBlockState());

--- a/src/main/java/com/mraof/minestuck/world/lands/terrain/ShadeLandType.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/terrain/ShadeLandType.java
@@ -41,10 +41,14 @@ public class ShadeLandType extends TerrainLandType
 		registry.setGroundState(MSBlocks.SHADE_STONE.defaultBlockState(), MSFillerBlockTypes.SHADE_STONE);
 		registry.setBlockState("upper", MSBlocks.BLUE_DIRT.defaultBlockState());
 		registry.setBlockState("ocean", MSBlocks.OIL.defaultBlockState());
-		registry.setBlockState("structure_primary_decorative", Blocks.CHISELED_STONE_BRICKS.defaultBlockState());
-		registry.setBlockState("structure_primary_stairs", Blocks.STONE_BRICK_STAIRS.defaultBlockState());
-		registry.setBlockState("structure_secondary", MSBlocks.SHADE_BRICKS.defaultBlockState());
-		registry.setBlockState("structure_secondary_decorative", MSBlocks.SMOOTH_SHADE_STONE.defaultBlockState());
+		registry.setBlockState("structure_primary", MSBlocks.SHADE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_decorative", MSBlocks.CHISELED_SHADE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_cracked", MSBlocks.CRACKED_SHADE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_mossy", MSBlocks.MOSSY_SHADE_BRICKS.defaultBlockState());
+		registry.setBlockState("structure_primary_column", MSBlocks.SHADE_COLUMN.defaultBlockState());
+		registry.setBlockState("structure_primary_stairs", MSBlocks.SHADE_STAIRS.defaultBlockState());
+		registry.setBlockState("structure_secondary", MSBlocks.SMOOTH_SHADE_STONE.defaultBlockState());
+		registry.setBlockState("structure_secondary_decorative", MSBlocks.TAR_SHADE_BRICKS.defaultBlockState());
 		registry.setBlockState("structure_secondary_stairs", MSBlocks.SHADE_BRICK_STAIRS.defaultBlockState());
 		registry.setBlockState("village_path", Blocks.GRAVEL.defaultBlockState());
 		registry.setBlockState("light_block", MSBlocks.GLOWING_WOOD.defaultBlockState());


### PR DESCRIPTION
An accumulative pull request (eventually) containing all the different pieces that have been worked on for it. Still some work to get done. Dweblenod and Midnight deserve a huge share of credit for doing the majority of the coding, with plenty of thanks going to Kirderf for reviewing and helping with code.

**Content:**
This update adds new dungeons intended to improve/linearize progression through the mod by requiring smaller dungeons to be completed before larger ones can be accessed(currently intended to be achieved through the use of keys and locked doors). This should allow for challenges to ramp up in difficulty and restrict certain alchemy items from being immediately accessible. The dungeons are currently going to be using recursive backtracking for randomized room organization to create branching paths in a maze like manner. It also offers additional utility functions to aide in the creation of further dungeons. Puzzle blocks #313 was intended for use here and that remains the intention. This also helps lay the foundation for the quest system although details on that will not be given here.

**Pull Requests:**
1. A
- 