### PR TITLE
Reimplement Grist layers

### DIFF
--- a/src/main/java/com/mraof/minestuck/client/util/GristLayerDebugRender.java
+++ b/src/main/java/com/mraof/minestuck/client/util/GristLayerDebugRender.java
@@ -42,12 +42,15 @@ public class GristLayerDebugRender
 			if(level == null)
 				return;
 			
-			GristLayerInfo.get(level).ifPresent(gristLayerInfo ->
-					renderGristLayer(event.getPoseStack(), event.getCamera(), minecraft.player, gristLayerInfo.getAnyGristLayer()));
+			GristLayerInfo.get(level).ifPresent(gristLayerInfo -> {
+				renderGristLayer(event.getPoseStack(), event.getCamera(), minecraft.player, gristLayerInfo.getCommonGristLayer(), 165);
+				renderGristLayer(event.getPoseStack(), event.getCamera(), minecraft.player, gristLayerInfo.getUncommonGristLayer(), 150);
+				renderGristLayer(event.getPoseStack(), event.getCamera(), minecraft.player, gristLayerInfo.getAnyGristLayer(), 135);
+			});
 		}
 	}
 	
-	private static void renderGristLayer(PoseStack stack, Camera camera, Player player, GristTypeLayer layer)
+	private static void renderGristLayer(PoseStack stack, Camera camera, Player player, GristTypeLayer layer, int y)
 	{
 		RenderSystem.setShader(GameRenderer::getPositionTexShader);
 		
@@ -58,7 +61,7 @@ public class GristLayerDebugRender
 				GristType type = layer.getTypeAt(x, z);
 				RenderSystem.setShaderTexture(0, type.getIcon());
 				stack.pushPose();
-				stack.translate(x - camera.getPosition().x, 135 - camera.getPosition().y, z - camera.getPosition().z);
+				stack.translate(x - camera.getPosition().x, y - camera.getPosition().y, z - camera.getPosition().z);
 				Matrix4f pose = stack.last().pose();
 				
 				BufferBuilder render = Tesselator.getInstance().getBuilder();

--- a/src/main/java/com/mraof/minestuck/client/util/GristLayerDebugRender.java
+++ b/src/main/java/com/mraof/minestuck/client/util/GristLayerDebugRender.java
@@ -20,7 +20,7 @@ import net.minecraftforge.fml.common.Mod;
 @Mod.EventBusSubscriber(Dist.CLIENT)
 public class GristLayerDebugRender
 {
-	private static final boolean RENDER = true;
+	private static final boolean RENDER = false;
 	private static final int RADIUS =  30;
 	
 	@SubscribeEvent

--- a/src/main/java/com/mraof/minestuck/client/util/GristLayerDebugRender.java
+++ b/src/main/java/com/mraof/minestuck/client/util/GristLayerDebugRender.java
@@ -21,7 +21,7 @@ import net.minecraftforge.fml.common.Mod;
 public class GristLayerDebugRender
 {
 	private static final boolean RENDER = true;
-	private static final int RADIUS =  16;
+	private static final int RADIUS =  30;
 	
 	@SubscribeEvent
 	public static void onRenderTick(RenderLevelStageEvent event)
@@ -58,7 +58,7 @@ public class GristLayerDebugRender
 				GristType type = layer.getTypeAt(x, z);
 				RenderSystem.setShaderTexture(0, type.getIcon());
 				stack.pushPose();
-				stack.translate(x - camera.getPosition().x, 100 - camera.getPosition().y, z - camera.getPosition().z);
+				stack.translate(x - camera.getPosition().x, 135 - camera.getPosition().y, z - camera.getPosition().z);
 				Matrix4f pose = stack.last().pose();
 				
 				BufferBuilder render = Tesselator.getInstance().getBuilder();

--- a/src/main/java/com/mraof/minestuck/client/util/GristLayerDebugRender.java
+++ b/src/main/java/com/mraof/minestuck/client/util/GristLayerDebugRender.java
@@ -1,0 +1,76 @@
+package com.mraof.minestuck.client.util;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.*;
+import com.mojang.math.Matrix4f;
+import com.mraof.minestuck.item.crafting.alchemy.GristType;
+import com.mraof.minestuck.world.lands.GristLayerInfo;
+import com.mraof.minestuck.world.lands.GristTypeLayer;
+import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderLevelStageEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(Dist.CLIENT)
+public class GristLayerDebugRender
+{
+	private static final boolean RENDER = true;
+	private static final int RADIUS =  16;
+	
+	@SubscribeEvent
+	public static void onRenderTick(RenderLevelStageEvent event)
+	{
+		if(RENDER && event.getStage() == RenderLevelStageEvent.Stage.AFTER_CUTOUT_BLOCKS)
+		{
+			Minecraft minecraft = Minecraft.getInstance();
+			
+			if(minecraft.level == null || minecraft.player == null)
+				return;
+			
+			MinecraftServer server = minecraft.getSingleplayerServer();
+			if(server == null)
+				return;
+			
+			ServerLevel level = server.getLevel(minecraft.level.dimension());
+			
+			if(level == null)
+				return;
+			
+			GristLayerInfo.get(level).ifPresent(gristLayerInfo ->
+					renderGristLayer(event.getPoseStack(), event.getCamera(), minecraft.player, gristLayerInfo.getAnyGristLayer()));
+		}
+	}
+	
+	private static void renderGristLayer(PoseStack stack, Camera camera, Player player, GristTypeLayer layer)
+	{
+		RenderSystem.setShader(GameRenderer::getPositionTexShader);
+		
+		for(int x = player.getBlockX() - RADIUS; x < player.getBlockX() + RADIUS; x++)
+		{
+			for(int z = player.getBlockZ() - RADIUS; z < player.getBlockZ() + RADIUS; z++)
+			{
+				GristType type = layer.getTypeAt(x, z);
+				RenderSystem.setShaderTexture(0, type.getIcon());
+				stack.pushPose();
+				stack.translate(x - camera.getPosition().x, 100 - camera.getPosition().y, z - camera.getPosition().z);
+				Matrix4f pose = stack.last().pose();
+				
+				BufferBuilder render = Tesselator.getInstance().getBuilder();
+				render.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+				render.vertex(pose, 0, 0, 1).uv(0, 1).endVertex();
+				render.vertex(pose, 1, 0, 1).uv(1, 1).endVertex();
+				render.vertex(pose, 1, 0, 0).uv(1, 0).endVertex();
+				render.vertex(pose, 0, 0, 0).uv(0, 0).endVertex();
+				Tesselator.getInstance().end();
+				stack.popPose();
+			}
+		}
+		
+	}
+}

--- a/src/main/java/com/mraof/minestuck/world/lands/GristLayerInfo.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/GristLayerInfo.java
@@ -123,6 +123,16 @@ public class GristLayerInfo
 		return new TranslatableComponent(INFO, commonType.getDisplayName(), uncommonType.getDisplayName(), anyType.getDisplayName());
 	}
 	
+	public GristTypeLayer getCommonGristLayer()
+	{
+		return commonGristLayer;
+	}
+	
+	public GristTypeLayer getUncommonGristLayer()
+	{
+		return uncommonGristLayer;
+	}
+	
 	public GristTypeLayer getAnyGristLayer()
 	{
 		return anyGristLayer;

--- a/src/main/java/com/mraof/minestuck/world/lands/GristLayerInfo.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/GristLayerInfo.java
@@ -122,4 +122,9 @@ public class GristLayerInfo
 		
 		return new TranslatableComponent(INFO, commonType.getDisplayName(), uncommonType.getDisplayName(), anyType.getDisplayName());
 	}
+	
+	public GristTypeLayer getAnyGristLayer()
+	{
+		return anyGristLayer;
+	}
 }

--- a/src/main/java/com/mraof/minestuck/world/lands/GristTypeLayer.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/GristTypeLayer.java
@@ -32,8 +32,8 @@ public class GristTypeLayer
 		this.areaSize = 1 << zoomLevel;
 		
 		PositionalRandomFactory randomFactory = WorldgenRandom.Algorithm.XOROSHIRO.newInstance(seed).forkPositional();
-		this.xShift = NormalNoise.create(randomFactory.fromHashOf("minestuck:grist_x_shift_" + index), -6, 1);
-		this.zShift = NormalNoise.create(randomFactory.fromHashOf("minestuck:grist_z_shift_" + index), -6, 1);
+		this.xShift = NormalNoise.create(randomFactory.fromHashOf("minestuck:grist_x_shift_" + index), -(zoomLevel - 1), 1);
+		this.zShift = NormalNoise.create(randomFactory.fromHashOf("minestuck:grist_z_shift_" + index), -(zoomLevel - 1), 1);
 		this.selectionRandom = randomFactory.fromHashOf("minestuck:grist_layer_" + index).forkPositional();
 	}
 	

--- a/src/main/java/com/mraof/minestuck/world/lands/GristTypeLayer.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/GristTypeLayer.java
@@ -2,69 +2,50 @@ package com.mraof.minestuck.world.lands;
 
 import com.mraof.minestuck.item.crafting.alchemy.GristType;
 import com.mraof.minestuck.item.crafting.alchemy.GristTypes;
+import net.minecraft.util.random.WeightedEntry;
+import net.minecraft.util.random.WeightedRandom;
+import net.minecraft.world.level.levelgen.PositionalRandomFactory;
+import net.minecraft.world.level.levelgen.WorldgenRandom;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 public class GristTypeLayer
-{/*
-	private final LazyArea area;
+{
+	private final List<WeightedEntry.Wrapper<GristType>> gristTypes;
+	private final int weightSum;
+	@Nullable
+	private final GristType baseType;
 	
-	private GristTypeLayer(LazyArea area)
+	private final PositionalRandomFactory selectionRandom;
+	
+	private GristTypeLayer(GristType.SpawnCategory category, int index, long seed, @Nullable GristType baseType)
 	{
-		this.area = area;
+		gristTypes = GristTypes.values().stream().filter(GristType::isUnderlingType)
+				.filter(gristType -> gristType.isInCategory(category))
+				.map(type -> WeightedEntry.wrap(type, Math.round(type.getRarity() * 100))).toList();
+		this.baseType = baseType;
+		weightSum = WeightedRandom.getTotalWeight(gristTypes);
+		
+		selectionRandom = WorldgenRandom.Algorithm.XOROSHIRO.newInstance(seed).forkPositional()
+				.fromHashOf("minestuck:grist_layer_" + index).forkPositional();
 	}
-	*/
+	
 	public static GristTypeLayer createLayer(GristType.SpawnCategory category, int index, long seed, int zoomLevel, @Nullable GristType baseType)
-	{/*
-		LongFunction<LazyAreaLayerContext> layerContextCreator = modifier -> new LazyAreaLayerContext(25, seed, modifier + index);
-		
-		IAreaFactory<LazyArea> layer = new BaseLayer(category, baseType).run(layerContextCreator.apply(250L));
-		layer = LayerUtil.zoom(2000L, ZoomLayer.NORMAL, layer, zoomLevel, layerContextCreator);
-		
-		return new GristTypeLayer(layer.make());*/
-		return new GristTypeLayer();
+	{
+		return new GristTypeLayer(category, index, seed, baseType);
 	}
 	
 	public GristType getTypeAt(int posX, int posZ)
 	{
-		/*int gristId = area.get(posX, posZ);
-		return ((ForgeRegistry<GristType>) GristTypes.getRegistry()).getValue(gristId);*/
-		return GristTypes.ARTIFACT.get();
+		return pickGristWithoutZoom(Math.floorDiv(posX, 8), Math.floorDiv(posZ, 8));
 	}
-	/*
-	private static class BaseLayer implements IAreaTransformer0
+	
+	private GristType pickGristWithoutZoom(int x, int z)
 	{
-		final List<GristEntry> gristTypes;
-		final int weightSum;
+		if(baseType != null && x * x + z * z <= 1)
+			return baseType;
 		
-		final int baseGristType;
-		
-		public BaseLayer(GristType.SpawnCategory category, @Nullable GristType type)
-		{
-			this.baseGristType = type == null ? -1 : ((ForgeRegistry<GristType>) GristTypes.getRegistry()).getID(type);
-			gristTypes = GristTypes.values().stream().filter(GristType::isUnderlingType)
-					.filter(gristType -> gristType.isInCategory(category)).map(GristEntry::new).collect(Collectors.toList());
-			weightSum = WeightedRandom.getTotalWeight(gristTypes);
-		}
-		
-		@Override
-		public int applyPixel(INoiseRandom context, int x, int z)
-		{
-			if(baseGristType != -1 && x * x + z * z <= 1)
-				return baseGristType;
-			
-			return WeightedRandom.getWeightedItem(gristTypes, context.nextRandom(weightSum)).gristId;
-		}
-		
-		private static class GristEntry extends WeightedRandom.Item
-		{
-			private final int gristId;
-			
-			public GristEntry(GristType type)
-			{
-				super(Math.round(type.getRarity() * 100));
-				this.gristId = ((ForgeRegistry<GristType>) GristTypes.getRegistry()).getID(type);
-			}
-		}
-	}*/
+		return WeightedRandom.getWeightedItem(gristTypes, selectionRandom.at(x, 0, z).nextInt(weightSum)).orElseThrow().getData();
+	}
 }


### PR DESCRIPTION
Reimplements grist layers. At its base, grist types are chosen per region as usual. However with the old biome layers removed, a new method was designed for creating irregular, random borders between grist regions. The new implementation uses noise fields to randomly shift the position used to get the base grist type.

To help tweak the noise field settings and shift factor, a debugging render tool was created to visualize grist types in layers in an area.