### PR TITLE
Add infiniverse as a dependency for registering land dimensions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ repositories {
             password = "\u0067hp_oGjcDFCn8jeTzIj4Ke9pLoEVtpnZMP4VQgaX"
         }
     }
+    maven {
+        // maven that contains infiniverse
+        url "https://cubicinterpolation.net/maven/"
+    }
 }
 
 version = project.getProperty('mc_ms_version')
@@ -137,6 +141,7 @@ dependencies {
     }
 
     implementation fg.deobf("software.bernie.geckolib:geckolib-${project.getProperty('mc_gecko_version')}")
+    implementation fg.deobf("commoble.infiniverse:${infiniverse_branch}:${infiniverse_version}")
 }
 
 sourceSets.main.resources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,6 @@ mc_jei_version=1.18.2:9.7.1.232
 mc_gecko_version=forge-1.18:3.0.34
 
 mc_refined_storage_version=1.10.3
+
+infiniverse_branch=infiniverse-1.18.2
+infiniverse_version=1.0.0.2

--- a/src/main/java/com/mraof/minestuck/world/DynamicDimensions.java
+++ b/src/main/java/com/mraof/minestuck/world/DynamicDimensions.java
@@ -1,105 +1,55 @@
 package com.mraof.minestuck.world;
 
-import com.google.common.collect.ImmutableList;
-import com.mojang.serialization.Lifecycle;
 import com.mraof.minestuck.Minestuck;
 import com.mraof.minestuck.world.gen.LandChunkGenerator;
 import com.mraof.minestuck.world.lands.LandTypePair;
-import net.minecraft.Util;
+import commoble.infiniverse.api.InfiniverseAPI;
 import net.minecraft.core.Registry;
-import net.minecraft.core.WritableRegistry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.progress.LoggerChunkProgressListener;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.biome.BiomeManager;
-import net.minecraft.world.level.border.BorderChangeListener;
 import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.dimension.LevelStem;
 import net.minecraft.world.level.levelgen.RandomSource;
-import net.minecraft.world.level.levelgen.WorldGenSettings;
 import net.minecraft.world.level.levelgen.WorldgenRandom;
-import net.minecraft.world.level.storage.DerivedLevelData;
-import net.minecraft.world.level.storage.LevelStorageSource;
-import net.minecraft.world.level.storage.WorldData;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.world.WorldEvent;
-import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
 
-import java.lang.reflect.Field;
-import java.util.Map;
 import java.util.Random;
 
-/**
- * Created with assistance from https://gist.github.com/Commoble/7db2ef25f94952a4d2e2b7e3d4be53e0
- */
 public class DynamicDimensions
 {
 	private static final ResourceKey<DimensionType> LAND_TYPE = ResourceKey.create(Registry.DIMENSION_TYPE_REGISTRY, new ResourceLocation(Minestuck.MOD_ID, "land"));
 	
 	public static ResourceKey<Level> createLand(MinecraftServer server, ResourceLocation baseName, LandTypePair landTypes)
 	{
-		Map<ResourceKey<Level>, ServerLevel> worldMap = server.forgeGetWorldMap();
+		ResourceKey<Level> worldKey = findUnusedWorldKey(server, baseName);
 		
-		ResourceKey<Level> worldKey = findUnusedWorldKey(worldMap, baseName);
-		
-		ResourceKey<LevelStem> dimensionKey = ResourceKey.create(Registry.LEVEL_STEM_REGISTRY, worldKey.location());
-		
-		WorldData worldData = server.getWorldData();
-		WorldGenSettings genSettings = worldData.worldGenSettings();
-		
-		RandomSource random = WorldgenRandom.Algorithm.XOROSHIRO.newInstance(genSettings.seed()).forkPositional().fromHashOf(worldKey.location());
-		LandTypePair.Named named = landTypes.createNamedRandomly(new Random(random.nextLong()));
-		ChunkGenerator chunkGenerator = LandChunkGenerator.create(server.registryAccess().registryOrThrow(Registry.STRUCTURE_SET_REGISTRY), server.registryAccess().registryOrThrow(Registry.NOISE_REGISTRY), server.registryAccess().registryOrThrow(Registry.DENSITY_FUNCTION_REGISTRY),
-				random.nextLong(), named, server.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY));
-		LevelStem dimension = new LevelStem(server.registryAccess().registryOrThrow(Registry.DIMENSION_TYPE_REGISTRY).getOrCreateHolder(LAND_TYPE), chunkGenerator);
-		
-		((WritableRegistry<LevelStem>) genSettings.dimensions()).register(dimensionKey, dimension, Lifecycle.experimental());
-		
-		LevelStorageSource.LevelStorageAccess levelSave = getLevelSave(server);
-		DerivedLevelData worldInfo = new DerivedLevelData(worldData, worldData.overworldData());
-		
-		ServerLevel level = new ServerLevel(server, Util.backgroundExecutor(), levelSave, worldInfo, worldKey,
-				dimension.typeHolder(), new LoggerChunkProgressListener(11), chunkGenerator, genSettings.isDebug(),
-				BiomeManager.obfuscateSeed(genSettings.seed()), ImmutableList.of(), false);
-		
-		server.overworld().getWorldBorder().addListener(new BorderChangeListener.DelegateBorderChangeListener(level.getWorldBorder()));
-		
-		worldMap.put(worldKey, level);
-		server.markWorldsDirty();
-		
-		MinecraftForge.EVENT_BUS.post(new WorldEvent.Load(level));
+		InfiniverseAPI.get().getOrCreateLevel(server, worldKey, () -> {
+			RandomSource random = WorldgenRandom.Algorithm.XOROSHIRO.newInstance(server.getWorldData().worldGenSettings().seed())
+					.forkPositional().fromHashOf(worldKey.location());
+			
+			LandTypePair.Named named = landTypes.createNamedRandomly(new Random(random.nextLong()));
+			long seed = random.nextLong();
+			
+			ChunkGenerator chunkGenerator = LandChunkGenerator.create(server.registryAccess().registryOrThrow(Registry.STRUCTURE_SET_REGISTRY), server.registryAccess().registryOrThrow(Registry.NOISE_REGISTRY), server.registryAccess().registryOrThrow(Registry.DENSITY_FUNCTION_REGISTRY),
+					seed, named, server.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY));
+			return new LevelStem(server.registryAccess().registryOrThrow(Registry.DIMENSION_TYPE_REGISTRY).getOrCreateHolder(LAND_TYPE), chunkGenerator);
+		});
 		
 		return worldKey;
 	}
 	
-	private static ResourceKey<Level> findUnusedWorldKey(Map<ResourceKey<Level>, ServerLevel> worldMap, ResourceLocation baseName)
+	private static ResourceKey<Level> findUnusedWorldKey(MinecraftServer server, ResourceLocation baseName)
 	{
 		ResourceKey<Level> key = ResourceKey.create(Registry.DIMENSION_REGISTRY, baseName);
 		
-		for(int i = 0; worldMap.containsKey(key); i++)
+		for(int i = 0; server.getLevel(key) != null; i++)
 		{
 			key = ResourceKey.create(Registry.DIMENSION_REGISTRY,
 					new ResourceLocation(baseName.getNamespace(), baseName.getPath() + "_" + i));
 		}
 		
 		return key;
-	}
-	
-	private static final Field LEVEL_SAVE_FIELD = ObfuscationReflectionHelper.findField(MinecraftServer.class, "f_129744_");
-	
-	private static LevelStorageSource.LevelStorageAccess getLevelSave(MinecraftServer server)
-	{
-		try
-		{
-			return (LevelStorageSource.LevelStorageAccess) (LEVEL_SAVE_FIELD.get(server));
-		}
-		catch (IllegalArgumentException | IllegalAccessException e)
-		{
-			throw new RuntimeException(e);
-		}
 	}
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -67,6 +67,13 @@ Adds Homestuck to your Minecraft!
     ordering="NONE"
     side="BOTH"
 
+[[dependencies.minestuck]]
+modId="infiniverse"
+mandatory=true
+versionRange="[1.0,1.1)"
+ordering="NONE"
+side="BOTH"
+
 # Here's another dependency
 [[dependencies.minestuck]]
     modId="minecraft"


### PR DESCRIPTION
I'd like to add this dependency to have a higher confidence that we're correctly adding land dimensions during runtime, both now and in future minecraft versions. Infiniverse also provide api for marking a dimension for removal, which we could make use of in the future to provide admin tools for unregistering abandoned land dimensions.
As a small bonus, Infiniverse syncs new dimensions to client-side, making them show up in the autocomplete for the `/execute in` command without needing to relog.