### PR TITLE
Held item deletion bug patch

### DIFF
--- a/src/main/java/com/mraof/minestuck/client/gui/playerStats/CaptchaDeckScreen.java
+++ b/src/main/java/com/mraof/minestuck/client/gui/playerStats/CaptchaDeckScreen.java
@@ -104,7 +104,7 @@ public class CaptchaDeckScreen extends PlayerStatsContainerScreen<CaptchaDeckMen
 	
 	private void sylladex()
 	{
-		if( ClientPlayerData.getModus() != null)
+		if( ClientPlayerData.getModus() != null && menu.getCarried().isEmpty())
 		{
 			minecraft.player.connection.send(new ServerboundContainerClosePacket(minecraft.player.containerMenu.containerId));
 			MSScreenFactories.displaySylladexScreen(ClientPlayerData.getModus());


### PR DESCRIPTION
When an item in the players inventory menu was being carried(held by mouse) and the button to enter the sylladex from the Minestuck menu was clicked, the item would not be transitioned to the resulting container menu and would instead be deleted. Players are no longer able to open their sylladex when holding an item