### PR TITLE
Minor Terrain component generation tweaks

### DIFF
--- a/src/main/java/com/mraof/minestuck/world/gen/feature/MSCFeatures.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/feature/MSCFeatures.java
@@ -113,7 +113,7 @@ public final class MSCFeatures
 			new RandomFeatureConfiguration(List.of(new WeightedPlacedFeature(TreePlacements.PINE_CHECKED, 1 / 3F)), TreePlacements.SPRUCE_CHECKED)));
 	
 	public static final RegistryObject<ConfiguredFeature<?, ?>> STRAWBERRY_PATCH = REGISTER.register("strawberry_patch", () -> new ConfiguredFeature<>(Feature.RANDOM_PATCH,
-			FeatureUtils.simplePatchConfiguration(Feature.SIMPLE_BLOCK, new SimpleBlockConfiguration(BlockStateProvider.simple(MSBlocks.STRAWBERRY.get())), List.of(Blocks.GRASS_BLOCK, Blocks.COARSE_DIRT), 4)));
+			FeatureUtils.simplePatchConfiguration(Feature.SIMPLE_BLOCK, new SimpleBlockConfiguration(BlockStateProvider.simple(MSBlocks.STRAWBERRY.get())), List.of(Blocks.GRASS_BLOCK, Blocks.COARSE_DIRT, Blocks.MUD), 4)));
 	public static final RegistryObject<ConfiguredFeature<?, ?>> GLOWING_MUSHROOM_PATCH = REGISTER.register("glowing_mushroom_patch", () -> new ConfiguredFeature<>(Feature.RANDOM_PATCH,
 			FeatureUtils.simpleRandomPatchConfiguration(32, PlacementUtils.onlyWhenEmpty(Feature.SIMPLE_BLOCK, new SimpleBlockConfiguration(BlockStateProvider.simple(MSBlocks.GLOWING_MUSHROOM.get().defaultBlockState()))))));
 	public static final RegistryObject<ConfiguredFeature<?, ?>> TALL_END_GRASS_PATCH = REGISTER.register("tall_end_grass_patch", () -> new ConfiguredFeature<>(Feature.RANDOM_PATCH,

--- a/src/main/java/com/mraof/minestuck/world/gen/feature/MSPlacedFeatures.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/feature/MSPlacedFeatures.java
@@ -92,9 +92,9 @@ public final class MSPlacedFeatures
 	public static final RegistryObject<PlacedFeature> STONE_SURFACE_DISK = REGISTER.register("stone_surface_disk", () -> placed(MSCFeatures.STONE_SURFACE_DISK,
 			worldGenModifiers(RarityFilter.onAverageOnceEvery(20), PlacementUtils.HEIGHTMAP_TOP_SOLID)));
 	public static final RegistryObject<PlacedFeature> END_GRASS_SURFACE_DISK = REGISTER.register("end_grass_surface_disk", () -> placed(MSCFeatures.END_GRASS_SURFACE_DISK,
-			singlePlacementModifiers(PlacementUtils.HEIGHTMAP_TOP_SOLID)));
+			worldGenModifiers(RarityFilter.onAverageOnceEvery(5), PlacementUtils.HEIGHTMAP_TOP_SOLID)));
 	public static final RegistryObject<PlacedFeature> END_STONE_SURFACE_DISK = REGISTER.register("end_stone_surface_disk", () -> placed(MSCFeatures.END_STONE_SURFACE_DISK,
-			singlePlacementModifiers(PlacementUtils.HEIGHTMAP_TOP_SOLID)));
+			worldGenModifiers(RarityFilter.onAverageOnceEvery(4), PlacementUtils.HEIGHTMAP_TOP_SOLID)));
 	
 	//these are similar to the ones in CavePlacements, but with edits to the height at which they generate and count
 	public static final RegistryObject<PlacedFeature> DRIPSTONE_CLUSTER = REGISTER.register("dripstone_cluster", () -> placed(CaveFeatures.DRIPSTONE_CLUSTER,
@@ -223,9 +223,9 @@ public final class MSPlacedFeatures
 			worldGenModifiers(RarityFilter.onAverageOnceEvery(128), PlacementUtils.HEIGHTMAP)));
 	
 	public static final RegistryObject<PlacedFeature> RABBIT_PLACEMENT = REGISTER.register("rabbit_placement", () -> placed(MSCFeatures.RABBIT_PLACEMENT,
-			singlePlacementModifiers(PlacementUtils.HEIGHTMAP)));
-	public static final RegistryObject<PlacedFeature> SMALL_RABBIT_PLACEMENT = REGISTER.register("small_rabbit_placement", () -> placed(MSCFeatures.RABBIT_PLACEMENT,
 			worldGenModifiers(RarityFilter.onAverageOnceEvery(2), PlacementUtils.HEIGHTMAP)));
+	public static final RegistryObject<PlacedFeature> SMALL_RABBIT_PLACEMENT = REGISTER.register("small_rabbit_placement", () -> placed(MSCFeatures.RABBIT_PLACEMENT,
+			worldGenModifiers(RarityFilter.onAverageOnceEvery(20), PlacementUtils.HEIGHTMAP)));
 	
 	public static final RegistryObject<PlacedFeature> CRUXITE_ORE = REGISTER.register("cruxite_ore", () -> placed(MSCFeatures.CRUXITE_ORE,
 			worldGenModifiers(CountPlacement.of(OreGeneration.cruxiteVeinsPerChunk), HeightRangePlacement.triangle(VerticalAnchor.absolute(OreGeneration.cruxiteStratumMin), VerticalAnchor.absolute(OreGeneration.cruxiteStratumMax)))));

--- a/src/main/java/com/mraof/minestuck/world/lands/terrain/FloraLandType.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/terrain/FloraLandType.java
@@ -44,9 +44,10 @@ public class FloraLandType extends TerrainLandType
 	public void registerBlocks(StructureBlockRegistry registry)
 	{
 		registry.setBlock("surface", Blocks.GRASS_BLOCK);
-		registry.setBlock("surface_rough", Blocks.COARSE_DIRT);
+		registry.setBlock("surface_rough", Blocks.MUD);
 		registry.setBlock("upper", Blocks.DIRT);
 		registry.setBlock("ocean", MSBlocks.BLOOD);
+		registry.setBlock("ocean_surface", Blocks.MUD);
 		registry.setBlock("structure_primary", MSBlocks.MOSSY_DECREPIT_STONE_BRICKS);
 		registry.setBlock("structure_primary_decorative", MSBlocks.FLOWERY_MOSSY_STONE_BRICKS);
 		registry.setBlock("structure_primary_mossy", MSBlocks.MOSSY_DECREPIT_STONE_BRICKS);

--- a/src/main/java/com/mraof/minestuck/world/lands/title/CakeLandType.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/title/CakeLandType.java
@@ -48,7 +48,7 @@ public class CakeLandType extends TitleLandType
 		
 		builder.addFeature(GenerationStep.Decoration.LOCAL_MODIFICATIONS, PlacementUtils.inlinePlaced(MSFeatures.CAKE.get(),
 						new ProbabilityFeatureConfiguration(biomeSet.getTemperature() / 2),
-						CountPlacement.of(UniformInt.of(0, 5)), InSquarePlacement.spread(), PlacementUtils.HEIGHTMAP_TOP_SOLID, BiomeFilter.biome()),
+						CountPlacement.of(UniformInt.of(0, 2)), InSquarePlacement.spread(), PlacementUtils.HEIGHTMAP_TOP_SOLID, BiomeFilter.biome()),
 				LandBiomeType.any());
 	}
 	

--- a/src/main/java/com/mraof/minestuck/world/lands/title/FrogsLandType.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/title/FrogsLandType.java
@@ -43,12 +43,12 @@ public class FrogsLandType extends TitleLandType
 	{
 		if(type == LandBiomeType.NORMAL)
 		{
-			builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(MSEntityTypes.FROG.get(), 1, 0, 1));
+			builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(MSEntityTypes.FROG.get(), 3, 0, 2));
 		}
 		
 		if(type == LandBiomeType.ROUGH)
 		{
-			builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(MSEntityTypes.FROG.get(), 10, 1, 6));
+			builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(MSEntityTypes.FROG.get(), 15, 1, 6));
 		}
 	}
 	


### PR DESCRIPTION
Replaces coarse dirt used in Flora land rough terrain with mud, reduced frequency of end grass/end stone surface disks in End lands, changing rabbit and frog generation frequency