### PR TITLE
Pillar tweak

### DIFF
--- a/src/main/java/com/mraof/minestuck/world/gen/feature/FeatureModifier.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/feature/FeatureModifier.java
@@ -13,61 +13,62 @@ import net.minecraft.world.level.levelgen.feature.stateproviders.RuleBasedBlockS
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 
 import java.util.Optional;
-import java.util.function.Function;
 
-public final class FeatureModifier
+public interface FeatureModifier
 {
-	public static Function<PlacedFeature, PlacedFeature> withTargets(BlockPredicate targets)
+	Holder<PlacedFeature> map(Holder<PlacedFeature> placedFeature);
+	
+	static FeatureModifier withTargets(BlockPredicate targets)
 	{
-		return configMap(new ConfigMapper()
+		return new ConfigMapper()
 		{
 			@SuppressWarnings("unchecked")
 			@Override
-			public <T extends FeatureConfiguration> T map(T config)
+			public <T extends FeatureConfiguration> Optional<T> maybeMap(T config)
 			{
 				if(config instanceof DiskConfiguration diskConfig)
-					return (T) new DiskConfiguration(diskConfig.stateProvider(), targets, diskConfig.radius(), diskConfig.halfHeight());
-				return config;
+					return Optional.of((T) new DiskConfiguration(diskConfig.stateProvider(), targets, diskConfig.radius(), diskConfig.halfHeight()));
+				return Optional.empty();
 			}
-		});
+		};
 	}
 	
-	public static Function<PlacedFeature, PlacedFeature> withState(BlockState state)
+	static FeatureModifier withState(BlockState state)
 	{
-		return configMap(new ConfigMapper()
+		return new ConfigMapper()
 		{
 			@SuppressWarnings("unchecked")
 			@Override
-			public <T extends FeatureConfiguration> T map(T config)
+			public <T extends FeatureConfiguration> Optional<T> maybeMap(T config)
 			{
 				if(config.getClass() == BlockStateConfiguration.class)
-					return (T) new BlockStateConfiguration(state);
+					return Optional.of((T) new BlockStateConfiguration(state));
 				if(config instanceof DiskConfiguration diskConfig)
-					return (T) new DiskConfiguration(RuleBasedBlockStateProvider.simple(BlockStateProvider.simple(state)), diskConfig.target(), diskConfig.radius(), diskConfig.halfHeight());
-				return config;
+					return Optional.of((T) new DiskConfiguration(RuleBasedBlockStateProvider.simple(BlockStateProvider.simple(state)),
+							diskConfig.target(), diskConfig.radius(), diskConfig.halfHeight()));
+				return Optional.empty();
 			}
-		});
+		};
 	}
 	
-	private static Function<PlacedFeature, PlacedFeature> configMap(ConfigMapper mapper)
+	interface ConfigMapper extends FeatureModifier
 	{
-		return placed -> mapConfigured(placed.feature().value(), mapper)
-				.map(newConfigured -> new PlacedFeature(Holder.direct(newConfigured), placed.placement()))
-				.orElse(placed);
-	}
-	
-	private static <FC extends FeatureConfiguration, F extends Feature<FC>> Optional<ConfiguredFeature<FC, F>> mapConfigured(ConfiguredFeature<FC, F> configured, ConfigMapper mapper)
-	{
-		FC oldConfig = configured.config();
-		FC newConfig = mapper.map(oldConfig);
-		if(oldConfig == newConfig)
-			return Optional.empty();
-		else
-			return Optional.of(new ConfiguredFeature<>(configured.feature(), newConfig));
-	}
-	
-	private interface ConfigMapper
-	{
-		<T extends FeatureConfiguration> T map(T config);
+		<T extends FeatureConfiguration> Optional<T> maybeMap(T config);
+		
+		default Optional<PlacedFeature> maybeMap(PlacedFeature placed)
+		{
+			return maybeMap(placed.feature().value()).map(newConfigured -> new PlacedFeature(Holder.direct(newConfigured), placed.placement()));
+		}
+		
+		default <FC extends FeatureConfiguration, F extends Feature<FC>> Optional<ConfiguredFeature<FC, F>> maybeMap(ConfiguredFeature<FC, F> configured)
+		{
+			return maybeMap(configured.config()).map(newConfig -> new ConfiguredFeature<>(configured.feature(), newConfig));
+		}
+		
+		@Override
+		default Holder<PlacedFeature> map(Holder<PlacedFeature> placedFeature)
+		{
+			return maybeMap(placedFeature.value()).map(Holder::direct).orElse(placedFeature);
+		}
 	}
 }

--- a/src/main/java/com/mraof/minestuck/world/gen/feature/MSCFeatures.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/feature/MSCFeatures.java
@@ -28,7 +28,6 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.RegistryObject;
 
 import java.util.List;
-import java.util.OptionalInt;
 
 /**
  * Holds minestuck configured features. Also creates and registers them when appropriate.
@@ -99,8 +98,10 @@ public final class MSCFeatures
 	public static final RegistryObject<ConfiguredFeature<?, ?>> RANDOM_ROCK_BLOCK_BLOB = REGISTER.register("random_rock_block_blob", () -> new ConfiguredFeature<>(MSFeatures.RANDOM_ROCK_BLOCK_BLOB.get(), new RandomRockBlockBlobConfig(3)));
 	public static final RegistryObject<ConfiguredFeature<?, ?>> LARGE_RANDOM_ROCK_BLOCK_BLOB = REGISTER.register("large_random_rock_block_blob", () -> new ConfiguredFeature<>(MSFeatures.RANDOM_ROCK_BLOCK_BLOB.get(), new RandomRockBlockBlobConfig(5)));
 	public static final RegistryObject<ConfiguredFeature<?, ?>> SHADE_STONE_BLOCK_BLOB = REGISTER.register("shade_stone_block_blob", () -> new ConfiguredFeature<>(MSFeatures.BLOCK_BLOB.get(), new BlockStateConfiguration(MSBlocks.SHADE_STONE.get().defaultBlockState())));
+	public static final RegistryObject<ConfiguredFeature<?, ?>> SMALL_PILLAR = REGISTER.register("small_pillar", () -> new ConfiguredFeature<>(MSFeatures.SMALL_PILLAR.get(), new BlockStateConfiguration(Blocks.STONE_BRICKS.defaultBlockState())));
 	public static final RegistryObject<ConfiguredFeature<?, ?>> PILLAR = REGISTER.register("pillar", () -> new ConfiguredFeature<>(MSFeatures.PILLAR.get(), new BlockStateConfiguration(Blocks.STONE_BRICKS.defaultBlockState())));
-	public static final RegistryObject<ConfiguredFeature<?, ?>> LARGE_PILLAR = REGISTER.register("large_pillar", () -> new ConfiguredFeature<>(MSFeatures.LARGE_PILLAR.get(), new BlockStateConfiguration(Blocks.STONE_BRICKS.defaultBlockState())));
+	public static final RegistryObject<ConfiguredFeature<?, ?>> MIXED_PILLARS = REGISTER.register("pillars", () -> new ConfiguredFeature<>(Feature.RANDOM_SELECTOR,
+			new RandomFeatureConfiguration(List.of(new WeightedPlacedFeature(PlacementUtils.inlinePlaced(PILLAR.getHolder().orElseThrow()), 0.4F)), PlacementUtils.inlinePlaced(SMALL_PILLAR.getHolder().orElseThrow()))));
 	
 	public static final RegistryObject<ConfiguredFeature<?, ?>> LARGE_CAKE = REGISTER.register("large_cake", () -> new ConfiguredFeature<>(MSFeatures.LARGE_CAKE.get(), FeatureConfiguration.NONE));
 	

--- a/src/main/java/com/mraof/minestuck/world/gen/feature/MSFeatures.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/feature/MSFeatures.java
@@ -43,8 +43,8 @@ public final class MSFeatures
 	public static final RegistryObject<Feature<BlockStateConfiguration>> STONE_MOUND = REGISTER.register("stone_mound", () -> new StoneMoundFeature(BlockStateConfiguration.CODEC));
 	public static final RegistryObject<Feature<BlockStateConfiguration>> BLOCK_BLOB = REGISTER.register("block_blob", () -> new ConditionFreeBlobFeature(BlockStateConfiguration.CODEC));
 	public static final RegistryObject<Feature<RandomRockBlockBlobConfig>> RANDOM_ROCK_BLOCK_BLOB = REGISTER.register("random_rock_block_blob", () -> new RandomRockConditionFreeBlobFeature(RandomRockBlockBlobConfig.CODEC));
-	public static final RegistryObject<Feature<BlockStateConfiguration>> PILLAR = REGISTER.register("pillar", () -> new PillarFeature(BlockStateConfiguration.CODEC, false));
-	public static final RegistryObject<Feature<BlockStateConfiguration>> LARGE_PILLAR = REGISTER.register("large_pillar", () -> new PillarFeature(BlockStateConfiguration.CODEC, true));
+	public static final RegistryObject<Feature<BlockStateConfiguration>> SMALL_PILLAR = REGISTER.register("small_pillar", () -> new SmallPillarFeature(BlockStateConfiguration.CODEC));
+	public static final RegistryObject<Feature<BlockStateConfiguration>> PILLAR = REGISTER.register("pillar", () -> new PillarFeature(BlockStateConfiguration.CODEC));
 	
 	public static final RegistryObject<Feature<NoneFeatureConfiguration>> END_TREE = REGISTER.register("end_tree", () -> new EndTreeFeature(NoneFeatureConfiguration.CODEC));
 	public static final RegistryObject<Feature<BlockStateConfiguration>> LEAFLESS_TREE = REGISTER.register("leafless_tree", () -> new LeaflessTreeFeature(BlockStateConfiguration.CODEC));

--- a/src/main/java/com/mraof/minestuck/world/gen/feature/MSPlacedFeatures.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/feature/MSPlacedFeatures.java
@@ -6,7 +6,6 @@ import com.mraof.minestuck.block.MSBlocks;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
-import net.minecraft.core.Vec3i;
 import net.minecraft.data.worldgen.features.*;
 import net.minecraft.data.worldgen.placement.PlacementUtils;
 import net.minecraft.util.valueproviders.ConstantInt;
@@ -144,11 +143,11 @@ public final class MSPlacedFeatures
 			worldGenModifiers(RarityFilter.onAverageOnceEvery(20), PlacementUtils.HEIGHTMAP_OCEAN_FLOOR)));
 	public static final RegistryObject<PlacedFeature> FOREST_ROCK = REGISTER.register("forest_rock", () -> placed(MiscOverworldFeatures.FOREST_ROCK,
 			worldGenModifiers(RarityFilter.onAverageOnceEvery(12), PlacementUtils.HEIGHTMAP_TOP_SOLID)));
-	public static final RegistryObject<PlacedFeature> PILLAR = REGISTER.register("pillar", () -> placed(MSCFeatures.PILLAR,
+	public static final RegistryObject<PlacedFeature> SMALL_PILLAR = REGISTER.register("small_pillar", () -> placed(MSCFeatures.SMALL_PILLAR,
 			worldGenModifiers(RarityFilter.onAverageOnceEvery(4), PlacementUtils.HEIGHTMAP_TOP_SOLID)));
-	public static final RegistryObject<PlacedFeature> LARGE_PILLAR = REGISTER.register("large_pillar", () -> placed(MSCFeatures.LARGE_PILLAR,
+	public static final RegistryObject<PlacedFeature> MIXED_PILLARS = REGISTER.register("mixed_pillars", () -> placed(MSCFeatures.MIXED_PILLARS,
 			singlePlacementModifiers(PlacementUtils.HEIGHTMAP_TOP_SOLID)));
-	public static final RegistryObject<PlacedFeature> LARGE_PILLAR_EXTRA = REGISTER.register("large_pillar_extra", () -> placed(MSCFeatures.LARGE_PILLAR,
+	public static final RegistryObject<PlacedFeature> MIXED_PILLARS_EXTRA = REGISTER.register("mixed_pillars_extra", () -> placed(MSCFeatures.MIXED_PILLARS,
 			worldGenModifiers(CountPlacement.of(3), PlacementUtils.HEIGHTMAP_TOP_SOLID)));
 	public static final RegistryObject<PlacedFeature> ICE_SPIKE = REGISTER.register("ice_spike", () -> placed(MiscOverworldFeatures.ICE_SPIKE,
 			worldGenModifiers(CountPlacement.of(16), PlacementUtils.HEIGHTMAP)));

--- a/src/main/java/com/mraof/minestuck/world/gen/feature/SmallPillarFeature.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/feature/SmallPillarFeature.java
@@ -9,9 +9,9 @@ import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 import net.minecraft.world.level.levelgen.feature.configurations.BlockStateConfiguration;
 
-public class PillarFeature extends Feature<BlockStateConfiguration>
+public class SmallPillarFeature extends Feature<BlockStateConfiguration>
 {
-	public PillarFeature(Codec<BlockStateConfiguration> codec)
+	public SmallPillarFeature(Codec<BlockStateConfiguration> codec)
 	{
 		super(codec);
 	}
@@ -28,13 +28,8 @@ public class PillarFeature extends Feature<BlockStateConfiguration>
 		if(level.getBlockState(pos.above(height - 1)).getMaterial().isLiquid())
 			return false;
 		
-		for(int i = 0; i < height + 3; i++)
-		{
-			setBlock(level, pos.offset(0, i, 0), state);
-			setBlock(level, pos.offset(1, i, 0), state);
-			setBlock(level, pos.offset(1, i, 1), state);
-			setBlock(level, pos.offset(0, i, 1), state);
-		}
+		for(int i = 0; i < height; i++)
+			setBlock(level, pos.above(i), state);
 		return true;
 	}
 }

--- a/src/main/java/com/mraof/minestuck/world/lands/LandBiomeGenBuilder.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/LandBiomeGenBuilder.java
@@ -1,13 +1,12 @@
 package com.mraof.minestuck.world.lands;
 
 import com.mraof.minestuck.world.biome.LandBiomeType;
+import com.mraof.minestuck.world.gen.feature.FeatureModifier;
 import net.minecraft.core.Holder;
 import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.carver.ConfiguredWorldCarver;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import net.minecraftforge.registries.RegistryObject;
-
-import java.util.function.Function;
 
 public interface LandBiomeGenBuilder
 {
@@ -18,12 +17,12 @@ public interface LandBiomeGenBuilder
 		addFeature(step, feature.getHolder().orElseThrow(), types);
 	}
 	
-	default void addModified(GenerationStep.Decoration step, Holder<PlacedFeature> feature, Function<PlacedFeature, PlacedFeature> modifier, LandBiomeType... types)
+	default void addModified(GenerationStep.Decoration step, Holder<PlacedFeature> feature, FeatureModifier modifier, LandBiomeType... types)
 	{
-		addFeature(step, Holder.direct(modifier.apply(feature.value())), types);
+		addFeature(step, modifier.map(feature), types);
 	}
 	
-	default void addModified(GenerationStep.Decoration step, RegistryObject<PlacedFeature> feature, Function<PlacedFeature, PlacedFeature> modifier, LandBiomeType... types)
+	default void addModified(GenerationStep.Decoration step, RegistryObject<PlacedFeature> feature, FeatureModifier modifier, LandBiomeType... types)
 	{
 		addModified(step, feature.getHolder().orElseThrow(), modifier, types);
 	}

--- a/src/main/java/com/mraof/minestuck/world/lands/title/LightLandType.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/title/LightLandType.java
@@ -52,8 +52,8 @@ public class LightLandType extends TitleLandType
 	{
 		BlockState lightBlock = blocks.getBlockState("light_block");
 		
-		builder.addModified(GenerationStep.Decoration.LOCAL_MODIFICATIONS, MSPlacedFeatures.LARGE_PILLAR_EXTRA, FeatureModifier.withState(lightBlock), LandBiomeType.ROUGH);
-		builder.addModified(GenerationStep.Decoration.LOCAL_MODIFICATIONS, MSPlacedFeatures.PILLAR, FeatureModifier.withState(lightBlock), LandBiomeType.anyExcept(LandBiomeType.ROUGH));
+		builder.addModified(GenerationStep.Decoration.LOCAL_MODIFICATIONS, MSPlacedFeatures.MIXED_PILLARS_EXTRA, FeatureModifier.withState(lightBlock), LandBiomeType.ROUGH);
+		builder.addModified(GenerationStep.Decoration.LOCAL_MODIFICATIONS, MSPlacedFeatures.SMALL_PILLAR, FeatureModifier.withState(lightBlock), LandBiomeType.anyExcept(LandBiomeType.ROUGH));
 		
 	}
 	

--- a/src/main/java/com/mraof/minestuck/world/lands/title/TowersLandType.java
+++ b/src/main/java/com/mraof/minestuck/world/lands/title/TowersLandType.java
@@ -37,7 +37,7 @@ public class TowersLandType extends TitleLandType
 	{
 		builder.addFeature(GenerationStep.Decoration.SURFACE_STRUCTURES, MSPlacedFeatures.TOWER, LandBiomeType.anyExcept(LandBiomeType.OCEAN));
 		
-		builder.addModified(GenerationStep.Decoration.LOCAL_MODIFICATIONS, MSPlacedFeatures.LARGE_PILLAR, FeatureModifier.withState(blocks.getBlockState("structure_primary")), LandBiomeType.ROUGH);
+		builder.addModified(GenerationStep.Decoration.LOCAL_MODIFICATIONS, MSPlacedFeatures.MIXED_PILLARS, FeatureModifier.withState(blocks.getBlockState("structure_primary")), LandBiomeType.ROUGH);
 		
 	}
 	


### PR DESCRIPTION
Tiny code cleanup change
Instead of one base feature with just small pillars and one base feature with both small and large pillars, there is now one for just small and one for just large pillars. These are then combined using `Feature.RANDOM_SELECTOR` to get the configured feature that places both kinds of pillars. The features also got some renames.

This change is purely technical, which regular players will not see.

I'm still not entirely sure which direction to take `FeatureModifier`, but I suppose that'll get cleared up as it gets more use.