### PR TITLE
Geckolib deprecations cleanup

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ mc_mappings_version=2022.11.27-1.19.2
 
 mc_jei_version=11.5.0.297
 
-mc_gecko_version=forge-1.19:3.1.23
+mc_gecko_version=forge-1.19:3.1.40
 
 mc_refined_storage_version=1.11.4
 

--- a/src/main/java/com/mraof/minestuck/blockentity/HorseClockBlockEntity.java
+++ b/src/main/java/com/mraof/minestuck/blockentity/HorseClockBlockEntity.java
@@ -14,10 +14,12 @@ import net.minecraft.world.phys.AABB;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.PlayState;
 import software.bernie.geckolib3.core.builder.AnimationBuilder;
+import software.bernie.geckolib3.core.builder.ILoopType;
 import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 /**
  * Block entity present in the bottom of the horse block multiblock. Keeps track of the time and lets off a tick sound each second, which makes the blocks give off a redstone signal.
@@ -25,7 +27,7 @@ import software.bernie.geckolib3.core.manager.AnimationFactory;
  */
 public class HorseClockBlockEntity extends BlockEntity implements IAnimatable
 {
-	private final AnimationFactory factory = new AnimationFactory(this);
+	private final AnimationFactory factory = GeckoLibUtil.createFactory(this);
 	private boolean hasChimed = false; //prevents the sound from getting stacked if the day time is frozen
 	
 	public HorseClockBlockEntity(BlockPos pos, BlockState state)
@@ -132,7 +134,7 @@ public class HorseClockBlockEntity extends BlockEntity implements IAnimatable
 	
 	private <E extends BlockEntity & IAnimatable> PlayState pendulumAnimation(AnimationEvent<E> event)
 	{
-		event.getController().setAnimation(new AnimationBuilder().addAnimation("ticktockontheclock", true));
+		event.getController().setAnimation(new AnimationBuilder().addAnimation("ticktockontheclock", ILoopType.EDefaultLoopTypes.LOOP));
 		return PlayState.CONTINUE;
 	}
 }

--- a/src/main/java/com/mraof/minestuck/blockentity/machine/AlchemiterBlockEntity.java
+++ b/src/main/java/com/mraof/minestuck/blockentity/machine/AlchemiterBlockEntity.java
@@ -35,16 +35,18 @@ import org.apache.logging.log4j.Logger;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.PlayState;
 import software.bernie.geckolib3.core.builder.AnimationBuilder;
+import software.bernie.geckolib3.core.builder.ILoopType;
 import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 public class AlchemiterBlockEntity extends BlockEntity implements IColored, GristWildcardHolder, IAnimatable
 {
 	private static final Logger LOGGER = LogManager.getLogger();
 	
-	private final AnimationFactory factory = new AnimationFactory(this);
+	private final AnimationFactory factory = GeckoLibUtil.createFactory(this);
 	
 	private GristType wildcardGrist = GristTypes.BUILD.get();
 	protected boolean broken = false;
@@ -348,7 +350,7 @@ public class AlchemiterBlockEntity extends BlockEntity implements IColored, Gris
 	{
 		if(!this.dowel.isEmpty())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("scan", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("scan", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		event.getController().markNeedsReload();

--- a/src/main/java/com/mraof/minestuck/blockentity/machine/TotemLatheDowelBlockEntity.java
+++ b/src/main/java/com/mraof/minestuck/blockentity/machine/TotemLatheDowelBlockEntity.java
@@ -14,18 +14,20 @@ import net.minecraft.world.phys.AABB;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.PlayState;
 import software.bernie.geckolib3.core.builder.AnimationBuilder;
+import software.bernie.geckolib3.core.builder.ILoopType;
 import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.ParticleKeyFrameEvent;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 import javax.annotation.Nullable;
 import java.awt.*;
 
 public class TotemLatheDowelBlockEntity extends ItemStackBlockEntity implements IAnimatable
 {
-	private final AnimationFactory factory = new AnimationFactory(this);
+	private final AnimationFactory factory = GeckoLibUtil.createFactory(this);
 	
 	public TotemLatheDowelBlockEntity(BlockPos pos, BlockState state)
 	{
@@ -90,7 +92,7 @@ public class TotemLatheDowelBlockEntity extends ItemStackBlockEntity implements 
 		TotemLatheBlockEntity totemLathe = getTotemLatheEntity();
 		if(totemLathe != null && totemLathe.isProcessing())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("carvetotem", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("carvetotem", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		event.getController().markNeedsReload();

--- a/src/main/java/com/mraof/minestuck/client/model/ServerCursorModel.java
+++ b/src/main/java/com/mraof/minestuck/client/model/ServerCursorModel.java
@@ -25,9 +25,9 @@ public class ServerCursorModel extends AnimatedGeoModel<ServerCursorEntity>
 	}
 	
 	@Override
-	public void setLivingAnimations(ServerCursorEntity entity, Integer uniqueID, AnimationEvent customPredicate)
+	public void setCustomAnimations(ServerCursorEntity entity, int uniqueID, AnimationEvent customPredicate)
 	{
-		super.setLivingAnimations(entity, uniqueID, customPredicate);
+		super.setCustomAnimations(entity, uniqueID, customPredicate);
 		IBone cursor = this.getAnimationProcessor().getBone("head");
 		
 		if(!entity.level.isClientSide || !Minecraft.getInstance().isPaused())

--- a/src/main/java/com/mraof/minestuck/client/model/entity/RotatingHeadAnimatedModel.java
+++ b/src/main/java/com/mraof/minestuck/client/model/entity/RotatingHeadAnimatedModel.java
@@ -13,8 +13,8 @@ import javax.annotation.Nullable;
  */
 public abstract class RotatingHeadAnimatedModel<T extends IAnimatable> extends AnimatedGeoModel<T> {
 	@Override
-	public void setLivingAnimations(T entity, Integer uniqueID, @Nullable AnimationEvent predicate) {
-		super.setLivingAnimations(entity, uniqueID, predicate);
+	public void setCustomAnimations(T entity, int uniqueID, @Nullable AnimationEvent predicate) {
+		super.setCustomAnimations(entity, uniqueID, predicate);
 		IBone head = this.getAnimationProcessor().getBone("head");
 		EntityModelData extraData = (EntityModelData) predicate.getExtraDataOfType(EntityModelData.class).get(0);
 		head.setRotationX(extraData.headPitch * ((float) Math.PI / 180F));

--- a/src/main/java/com/mraof/minestuck/client/renderer/blockentity/TotemLatheRenderer.java
+++ b/src/main/java/com/mraof/minestuck/client/renderer/blockentity/TotemLatheRenderer.java
@@ -70,8 +70,8 @@ public class TotemLatheRenderer extends GeoBlockRenderer<TotemLatheDowelBlockEnt
 			
 			// position adjustments
 			stack.pushPose();
-			RenderUtils.translate(bone, stack);
-			RenderUtils.moveToPivot(bone, stack);
+			RenderUtils.translateMatrixToBone(stack, bone);
+			RenderUtils.translateToPivotPoint(stack, bone);
 			stack.translate(0.25, -0.375, 0.03125);
 			stack.mulPose(Vector3f.ZP.rotationDegrees(90));
 			

--- a/src/main/java/com/mraof/minestuck/entity/LotusFlowerEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/LotusFlowerEntity.java
@@ -1,12 +1,11 @@
 package com.mraof.minestuck.entity;
 
 import com.mraof.minestuck.MinestuckConfig;
-import com.mraof.minestuck.item.IncompleteSburbCodeItem;
-import com.mraof.minestuck.item.MSItems;
 import com.mraof.minestuck.item.loot.MSLootTables;
 import com.mraof.minestuck.network.LotusFlowerPacket;
 import com.mraof.minestuck.network.MSPacketHandler;
 import com.mraof.minestuck.util.MSSoundEvents;
+import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
@@ -33,15 +32,20 @@ import org.apache.logging.log4j.Logger;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.PlayState;
 import software.bernie.geckolib3.core.builder.AnimationBuilder;
+import software.bernie.geckolib3.core.builder.ILoopType;
 import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Collections;
 import java.util.List;
 
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class LotusFlowerEntity extends LivingEntity implements IAnimatable, IEntityAdditionalSpawnData
 {
 	private static final Logger LOGGER = LogManager.getLogger();
@@ -58,7 +62,7 @@ public class LotusFlowerEntity extends LivingEntity implements IAnimatable, IEnt
 	private static final int VANISH_START = OPEN_IDLE_START + OPEN_IDLE_LENGTH;
 	private static final int ANIMATION_END = VANISH_START + VANISHING_LENGTH;
 	
-	private final AnimationFactory factory = new AnimationFactory(this);
+	private final AnimationFactory factory = GeckoLibUtil.createFactory(this);
 	
 	//Only used server-side. Used to track the flower state and the progression of the animation
 	private int eventTimer = IDLE_TIME;
@@ -78,7 +82,7 @@ public class LotusFlowerEntity extends LivingEntity implements IAnimatable, IEnt
 	
 	private <E extends IAnimatable> PlayState predicate(AnimationEvent<E> event)
 	{
-		event.getController().setAnimation(new AnimationBuilder().addAnimation(animation.animationName, true));
+		event.getController().setAnimation(new AnimationBuilder().addAnimation(animation.animationName, ILoopType.EDefaultLoopTypes.LOOP));
 		
 		return PlayState.CONTINUE;
 	}

--- a/src/main/java/com/mraof/minestuck/entity/ServerCursorEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/ServerCursorEntity.java
@@ -2,6 +2,7 @@ package com.mraof.minestuck.entity;
 
 import com.mraof.minestuck.network.MSPacketHandler;
 import com.mraof.minestuck.network.ServerCursorPacket;
+import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.FriendlyByteBuf;
@@ -21,14 +22,18 @@ import software.bernie.geckolib3.core.controller.AnimationController;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Collections;
 
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class ServerCursorEntity extends LivingEntity implements IAnimatable, IEntityAdditionalSpawnData
 {
 	
-	private final AnimationFactory factory = new AnimationFactory(this);
+	private final AnimationFactory factory = GeckoLibUtil.createFactory(this);
 	
 	//These are only used server-side to make sure cursors are removed properly.
 	private int despawnTimer = 0;

--- a/src/main/java/com/mraof/minestuck/entity/carapacian/PawnEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/carapacian/PawnEntity.java
@@ -33,19 +33,23 @@ import net.minecraft.world.level.ServerLevelAccessor;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.PlayState;
 import software.bernie.geckolib3.core.builder.AnimationBuilder;
+import software.bernie.geckolib3.core.builder.ILoopType;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class PawnEntity extends CarapacianEntity implements RangedAttackMob, Enemy, IAnimatable, PhasedMobAnimation.Phases.Holder
 {
 	private static final EntityDataAccessor<Integer> CURRENT_ACTION = SynchedEntityData.defineId(PawnEntity.class, EntityDataSerializers.INT);
 	
 	public static final PhasedMobAnimation MELEE_ANIMATION = new PhasedMobAnimation(new MobAnimation(MobAnimation.Action.MELEE, 18, true, false), 3, 6, 7);
 	
-	private final AnimationFactory factory = new AnimationFactory(this);
+	private final AnimationFactory factory = GeckoLibUtil.createFactory(this);
 	private final RangedAttackGoal aiArrowAttack = new RangedAttackGoal(this, 5 / 4F, 20, 10.0F);
 	private final MeleeAttackGoal aiMeleeAttack = new MeleeAttackGoal(this, 2F, false);
 	
@@ -180,19 +184,6 @@ public class PawnEntity extends CarapacianEntity implements RangedAttackMob, Ene
 		
 		return par1Entity.hurt(DamageSource.mobAttack(this), damage);
 	}
-
-//	/**
-//	 * Basic mob attack. Default to touch of death in EntityCreature. Overridden by each mob to define their attack.
-//	 */
-//	@Override
-//	protected void attackEntity(Entity par1Entity, float par2)
-//	{
-//		if (this.attackTime <= 0 && par2 < 2.0F && par1Entity.getEntityBoundingBox().maxY > this.getEntityBoundingBox().minY && par1Entity.getEntityBoundingBox().minY < this.getEntityBoundingBox().maxY)
-//		{
-//			this.attackTime = 20;
-//			this.attackEntityAsMob(par1Entity);
-//		}
-//	}
 	
 	private void setCombatTask()
 	{
@@ -254,7 +245,7 @@ public class PawnEntity extends CarapacianEntity implements RangedAttackMob, Ene
 	{
 		if(event.isMoving())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("walk", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("walk", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;
@@ -264,7 +255,7 @@ public class PawnEntity extends CarapacianEntity implements RangedAttackMob, Ene
 	{
 		if(event.isMoving() && !event.getAnimatable().isActive())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("walkarms", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("walkarms", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;
@@ -274,7 +265,7 @@ public class PawnEntity extends CarapacianEntity implements RangedAttackMob, Ene
 	{
 		if(event.getAnimatable().dead)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("die", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("die", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;
@@ -284,7 +275,7 @@ public class PawnEntity extends CarapacianEntity implements RangedAttackMob, Ene
 	{
 		if(event.getAnimatable().isActive())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("punch1", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("punch1", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		event.getController().markNeedsReload();

--- a/src/main/java/com/mraof/minestuck/entity/consort/ConsortEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/consort/ConsortEntity.java
@@ -13,6 +13,7 @@ import com.mraof.minestuck.player.PlayerIdentifier;
 import com.mraof.minestuck.util.AnimationControllerUtil;
 import com.mraof.minestuck.player.PlayerSavedData;
 import com.mraof.minestuck.world.MSDimensions;
+import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -47,14 +48,19 @@ import org.slf4j.Logger;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.PlayState;
 import software.bernie.geckolib3.core.builder.AnimationBuilder;
+import software.bernie.geckolib3.core.builder.ILoopType;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.HashSet;
 import java.util.Set;
 
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class ConsortEntity extends AnimatedPathfinderMob implements MenuProvider, IAnimatable
 {
 	private static final Logger LOGGER = LogUtils.getLogger();
@@ -62,7 +68,7 @@ public class ConsortEntity extends AnimatedPathfinderMob implements MenuProvider
 	public static final MobAnimation TALK_ANIMATION = new MobAnimation(MobAnimation.Action.TALK, 80, true, false); //TODO adjust as needed - 4 secs for now
 	public static final MobAnimation PANIC_ANIMATION = new MobAnimation(MobAnimation.Action.PANIC, MobAnimation.LOOPING_ANIMATION, false, false);
 	
-	private final AnimationFactory factory = new AnimationFactory(this);
+	private final AnimationFactory factory = GeckoLibUtil.createFactory(this);
 	private final EnumConsort consortType;
 	private boolean hasHadMessage = false;
 	ConsortDialogue.DialogueWrapper message;
@@ -450,7 +456,7 @@ public class ConsortEntity extends AnimatedPathfinderMob implements MenuProvider
 			return PlayState.STOP;
 		}
 		
-		event.getController().setAnimation(new AnimationBuilder().addAnimation("idle", true));
+		event.getController().setAnimation(new AnimationBuilder().addAnimation("idle", ILoopType.EDefaultLoopTypes.LOOP));
 		return PlayState.CONTINUE;
 	}
 	
@@ -466,18 +472,18 @@ public class ConsortEntity extends AnimatedPathfinderMob implements MenuProvider
 		if(action == MobAnimation.Action.PANIC)
 		{
 			//TODO add a system for the panic animation intended to precede this
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("panicrun", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("panicrun", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		} else if(action != MobAnimation.Action.IDLE)
 		{
 			return PlayState.STOP;
 		} else if(event.getAnimatable().jumping)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("jump", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("jump", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		else {
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("walk", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("walk", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		}
 	}
@@ -489,7 +495,7 @@ public class ConsortEntity extends AnimatedPathfinderMob implements MenuProvider
 			return PlayState.STOP;
 		}
 		
-		event.getController().setAnimation(new AnimationBuilder().addAnimation("walkarms", true));
+		event.getController().setAnimation(new AnimationBuilder().addAnimation("walkarms", ILoopType.EDefaultLoopTypes.LOOP));
 		return PlayState.CONTINUE;
 	}
 	
@@ -497,7 +503,7 @@ public class ConsortEntity extends AnimatedPathfinderMob implements MenuProvider
 	{
 		if(event.getAnimatable().dead)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("die", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("die", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;
@@ -508,7 +514,7 @@ public class ConsortEntity extends AnimatedPathfinderMob implements MenuProvider
 		MobAnimation.Action action = event.getAnimatable().getCurrentAction();
 		if(action == MobAnimation.Action.TALK)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("talk", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("talk", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		}
 		

--- a/src/main/java/com/mraof/minestuck/entity/underling/BasiliskEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/underling/BasiliskEntity.java
@@ -24,9 +24,13 @@ import net.minecraftforge.entity.PartEntity;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.PlayState;
 import software.bernie.geckolib3.core.builder.AnimationBuilder;
+import software.bernie.geckolib3.core.builder.ILoopType;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class BasiliskEntity extends UnderlingEntity implements IAnimatable
 {
 	public static final PhasedMobAnimation TAIL_SWING_ANIMATION = new PhasedMobAnimation(new MobAnimation(MobAnimation.Action.SWING, 12, true, false), 2, 4, 6);
@@ -232,11 +236,11 @@ public class BasiliskEntity extends UnderlingEntity implements IAnimatable
 		
 		if(event.getAnimatable().isAggressive())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("run", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("run", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		} else
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("walk", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("walk", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		}
 	}
@@ -245,7 +249,7 @@ public class BasiliskEntity extends UnderlingEntity implements IAnimatable
 	{
 		if(event.getAnimatable().dead)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("die", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("die", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;
@@ -257,15 +261,15 @@ public class BasiliskEntity extends UnderlingEntity implements IAnimatable
 		
 		if(action == MobAnimation.Action.BITE)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("bite", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("bite", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		} else if(action == MobAnimation.Action.SWING)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("tail_whip", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("tail_whip", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		} else if(action == MobAnimation.Action.SHOOT)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("shoot", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("shoot", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		

--- a/src/main/java/com/mraof/minestuck/entity/underling/GiclopsEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/underling/GiclopsEntity.java
@@ -26,9 +26,13 @@ import net.minecraft.world.phys.AABB;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.PlayState;
 import software.bernie.geckolib3.core.builder.AnimationBuilder;
+import software.bernie.geckolib3.core.builder.ILoopType;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class GiclopsEntity extends UnderlingEntity implements IAnimatable
 {
 	public static final PhasedMobAnimation KICK_ANIMATION = new PhasedMobAnimation(new MobAnimation(MobAnimation.Action.KICK, 40, true, true), 18, 20, 22);
@@ -178,7 +182,7 @@ public class GiclopsEntity extends UnderlingEntity implements IAnimatable
 			return PlayState.STOP;
 		}
 		
-		event.getController().setAnimation(new AnimationBuilder().addAnimation("idle", true));
+		event.getController().setAnimation(new AnimationBuilder().addAnimation("idle", ILoopType.EDefaultLoopTypes.LOOP));
 		return PlayState.CONTINUE;
 	}
 	
@@ -186,7 +190,7 @@ public class GiclopsEntity extends UnderlingEntity implements IAnimatable
 	{
 		if(event.isMoving())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("walk", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("walk", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;
@@ -198,7 +202,7 @@ public class GiclopsEntity extends UnderlingEntity implements IAnimatable
 		
 		if(action == MobAnimation.Action.KICK)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("kick", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("kick", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		
@@ -210,7 +214,7 @@ public class GiclopsEntity extends UnderlingEntity implements IAnimatable
 	{
 		if(event.getAnimatable().dead)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("death", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("death", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;

--- a/src/main/java/com/mraof/minestuck/entity/underling/ImpEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/underling/ImpEntity.java
@@ -24,9 +24,13 @@ import net.minecraft.world.level.Level;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.PlayState;
 import software.bernie.geckolib3.core.builder.AnimationBuilder;
+import software.bernie.geckolib3.core.builder.ILoopType;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class ImpEntity extends UnderlingEntity implements IAnimatable
 {
 	public static final PhasedMobAnimation CLAW_ANIMATION = new PhasedMobAnimation(new MobAnimation(MobAnimation.Action.CLAW, 8, true, false), 2, 4, 5);
@@ -131,7 +135,7 @@ public class ImpEntity extends UnderlingEntity implements IAnimatable
 	{
 		if(!event.isMoving() && !event.getAnimatable().isAggressive())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.idle", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.idle", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;
@@ -146,11 +150,11 @@ public class ImpEntity extends UnderlingEntity implements IAnimatable
 		
 		if(event.getAnimatable().isAggressive())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.run", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.run", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		} else
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.walk", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.walk", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		}
 	}
@@ -164,11 +168,11 @@ public class ImpEntity extends UnderlingEntity implements IAnimatable
 		
 		if(event.getAnimatable().isAggressive())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.runarms", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.runarms", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		} else
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.walkarms", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.walkarms", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		}
 	}
@@ -177,7 +181,7 @@ public class ImpEntity extends UnderlingEntity implements IAnimatable
 	{
 		if(event.getAnimatable().dead)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.die", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.die", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;
@@ -187,7 +191,7 @@ public class ImpEntity extends UnderlingEntity implements IAnimatable
 	{
 		if(event.getAnimatable().isActive())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.scratch", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("animation.minestuck.imp.scratch", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		event.getController().markNeedsReload();

--- a/src/main/java/com/mraof/minestuck/entity/underling/LichEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/underling/LichEntity.java
@@ -24,11 +24,14 @@ import net.minecraft.world.level.Level;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.PlayState;
 import software.bernie.geckolib3.core.builder.AnimationBuilder;
+import software.bernie.geckolib3.core.builder.ILoopType;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.UUID;
 
+@ParametersAreNonnullByDefault
 public class LichEntity extends UnderlingEntity implements IAnimatable
 {
 	public static final PhasedMobAnimation CLAW_ANIMATION = new PhasedMobAnimation(new MobAnimation(MobAnimation.Action.CLAW, 10, false, false), 5, 6, 7);
@@ -139,7 +142,7 @@ public class LichEntity extends UnderlingEntity implements IAnimatable
 			return PlayState.STOP;
 		}
 		
-		event.getController().setAnimation(new AnimationBuilder().addAnimation("idle", true));
+		event.getController().setAnimation(new AnimationBuilder().addAnimation("idle", ILoopType.EDefaultLoopTypes.LOOP));
 		return PlayState.CONTINUE;
 	}
 	
@@ -149,14 +152,14 @@ public class LichEntity extends UnderlingEntity implements IAnimatable
 		
 		if(action == MobAnimation.Action.CLAW)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("claw_legs", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("claw_legs", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		} else if(!event.isMoving())
 		{
 			return PlayState.STOP;
 		} else
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("walk", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("walk", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		}
 	}
@@ -165,7 +168,7 @@ public class LichEntity extends UnderlingEntity implements IAnimatable
 	{
 		if(event.getAnimatable().dead)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("die", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("die", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;
@@ -175,7 +178,7 @@ public class LichEntity extends UnderlingEntity implements IAnimatable
 	{
 		if(event.getAnimatable().isActive())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("claw_arms", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("claw_arms", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		event.getController().markNeedsReload();

--- a/src/main/java/com/mraof/minestuck/entity/underling/OgreEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/underling/OgreEntity.java
@@ -21,10 +21,14 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
 import software.bernie.geckolib3.core.PlayState;
 import software.bernie.geckolib3.core.builder.AnimationBuilder;
+import software.bernie.geckolib3.core.builder.ILoopType;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
 //Makes non-stop ogre puns
+@ParametersAreNonnullByDefault
 public class OgreEntity extends UnderlingEntity
 {
 	public static final PhasedMobAnimation PUNCH_ANIMATION = new PhasedMobAnimation(new MobAnimation(MobAnimation.Action.PUNCH, 22, true, true), 7, 10, 13);
@@ -124,7 +128,7 @@ public class OgreEntity extends UnderlingEntity
 	{
 		if(event.isMoving())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("walk", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("walk", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;
@@ -134,7 +138,7 @@ public class OgreEntity extends UnderlingEntity
 	{
 		if(event.isMoving() && !event.getAnimatable().isActive())
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("walkarms", true));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("walkarms", ILoopType.EDefaultLoopTypes.LOOP));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;
@@ -146,11 +150,11 @@ public class OgreEntity extends UnderlingEntity
 		
 		if(action == MobAnimation.Action.PUNCH)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("punch", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("punch", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		} else if(action == MobAnimation.Action.SLAM)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("smash", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("smash", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		
@@ -162,7 +166,7 @@ public class OgreEntity extends UnderlingEntity
 	{
 		if(event.getAnimatable().dead)
 		{
-			event.getController().setAnimation(new AnimationBuilder().addAnimation("die", false));
+			event.getController().setAnimation(new AnimationBuilder().addAnimation("die", ILoopType.EDefaultLoopTypes.PLAY_ONCE));
 			return PlayState.CONTINUE;
 		}
 		return PlayState.STOP;

--- a/src/main/java/com/mraof/minestuck/entity/underling/UnderlingEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/underling/UnderlingEntity.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
+import software.bernie.geckolib3.util.GeckoLibUtil;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -54,7 +55,7 @@ public abstract class UnderlingEntity extends AttackingAnimatedEntity implements
 	public static final UUID GRIST_MODIFIER_ID = UUID.fromString("08B6DEFC-E3F4-11EA-87D0-0242AC130003");
 	private static final EntityDataAccessor<String> GRIST_TYPE = SynchedEntityData.defineId(UnderlingEntity.class, EntityDataSerializers.STRING);
 	
-	private final AnimationFactory factory = new AnimationFactory(this);
+	private final AnimationFactory factory = GeckoLibUtil.createFactory(this);
 	protected final EntityListFilter attackEntitySelector = new EntityListFilter(new ArrayList<>());    //TODO this filter isn't being saved. F1X PLZ
 	protected boolean fromSpawner;
 	public boolean dropCandy;


### PR DESCRIPTION
Updates geckolib to the latest version for this minecraft version, and handles all deprecations that geckolib has made. This should prepare us for moving over to Geckolib 4 when we eventually update to a newer mc version.