### PR TITLE
Minor change to player data handling

### DIFF
--- a/src/main/java/com/mraof/minestuck/inventory/captchalogue/HashMapModus.java
+++ b/src/main/java/com/mraof/minestuck/inventory/captchalogue/HashMapModus.java
@@ -3,7 +3,6 @@ package com.mraof.minestuck.inventory.captchalogue;
 import com.mraof.minestuck.MinestuckConfig;
 import com.mraof.minestuck.alchemy.AlchemyHelper;
 import com.mraof.minestuck.item.MSItems;
-import com.mraof.minestuck.player.PlayerSavedData;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -25,9 +24,9 @@ public class HashMapModus extends Modus
 	protected boolean changed;
 	protected NonNullList<ItemStack> items;
 	
-	public HashMapModus(ModusType<? extends HashMapModus> type, PlayerSavedData savedData, LogicalSide side)
+	public HashMapModus(ModusType<? extends HashMapModus> type, LogicalSide side)
 	{
-		super(type, savedData, side);
+		super(type, side);
 	}
 	
 	@Override

--- a/src/main/java/com/mraof/minestuck/inventory/captchalogue/Modus.java
+++ b/src/main/java/com/mraof/minestuck/inventory/captchalogue/Modus.java
@@ -2,11 +2,9 @@ package com.mraof.minestuck.inventory.captchalogue;
 
 import com.mraof.minestuck.network.MSPacketHandler;
 import com.mraof.minestuck.network.data.ModusDataPacket;
-import com.mraof.minestuck.player.PlayerSavedData;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fml.LogicalSide;
@@ -15,15 +13,13 @@ import java.util.Objects;
 
 public abstract class Modus
 {
-	private final PlayerSavedData savedData;
 	private final ModusType<?> type;
 	public final LogicalSide side;
 	private boolean needResend;
 	
-	public Modus(ModusType<?> type, PlayerSavedData savedData, LogicalSide side)
+	public Modus(ModusType<?> type, LogicalSide side)
 	{
 		this.type = Objects.requireNonNull(type);
-		this.savedData = side == LogicalSide.SERVER ? Objects.requireNonNull(savedData) : null;
 		this.side = Objects.requireNonNull(side);
 	}
 	
@@ -81,8 +77,6 @@ public abstract class Modus
 	 */
 	public void markDirty()
 	{
-		if(savedData != null)
-			savedData.setDirty();
 		needResend = true;
 	}
 	
@@ -93,10 +87,5 @@ public abstract class Modus
 			MSPacketHandler.sendToPlayer(ModusDataPacket.create(this), player);
 			needResend = false;
 		}
-	}
-	
-	protected MinecraftServer getServer()
-	{
-		return savedData != null ? savedData.mcServer : null;
 	}
 }

--- a/src/main/java/com/mraof/minestuck/inventory/captchalogue/ModusType.java
+++ b/src/main/java/com/mraof/minestuck/inventory/captchalogue/ModusType.java
@@ -1,6 +1,5 @@
 package com.mraof.minestuck.inventory.captchalogue;
 
-import com.mraof.minestuck.player.PlayerSavedData;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.fml.LogicalSide;
 
@@ -20,12 +19,12 @@ public final class ModusType<T extends Modus>
 	
 	public T createClientSide()
 	{
-		return factory.create(this, null, LogicalSide.CLIENT);
+		return factory.create(this, LogicalSide.CLIENT);
 	}
 	
-	public T createServerSide(PlayerSavedData savedData)
+	public T createServerSide()
 	{
-		return factory.create(this, savedData, LogicalSide.SERVER);
+		return factory.create(this, LogicalSide.SERVER);
 	}
 	
 	public Item getItem()
@@ -35,6 +34,6 @@ public final class ModusType<T extends Modus>
 	
 	public interface ModusFactory<T extends Modus>
 	{
-		T create(ModusType<T> type, PlayerSavedData savedData, LogicalSide side);
+		T create(ModusType<T> type, LogicalSide side);
 	}
 }

--- a/src/main/java/com/mraof/minestuck/inventory/captchalogue/QueueModus.java
+++ b/src/main/java/com/mraof/minestuck/inventory/captchalogue/QueueModus.java
@@ -1,8 +1,7 @@
 package com.mraof.minestuck.inventory.captchalogue;
 
-import com.mraof.minestuck.item.MSItems;
 import com.mraof.minestuck.alchemy.AlchemyHelper;
-import com.mraof.minestuck.player.PlayerSavedData;
+import com.mraof.minestuck.item.MSItems;
 import net.minecraft.core.NonNullList;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
@@ -13,9 +12,9 @@ import java.util.Iterator;
 public class QueueModus extends StackModus
 {
 	
-	public QueueModus(ModusType<? extends QueueModus> type, PlayerSavedData savedData, LogicalSide side)
+	public QueueModus(ModusType<? extends QueueModus> type, LogicalSide side)
 	{
-		super(type, savedData, side);
+		super(type, side);
 	}
 	
 	@Override

--- a/src/main/java/com/mraof/minestuck/inventory/captchalogue/QueueStackModus.java
+++ b/src/main/java/com/mraof/minestuck/inventory/captchalogue/QueueStackModus.java
@@ -2,7 +2,6 @@ package com.mraof.minestuck.inventory.captchalogue;
 
 import com.mraof.minestuck.item.MSItems;
 import com.mraof.minestuck.alchemy.AlchemyHelper;
-import com.mraof.minestuck.player.PlayerSavedData;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fml.LogicalSide;
@@ -10,9 +9,9 @@ import net.minecraftforge.fml.LogicalSide;
 public class QueueStackModus extends StackModus
 {
 	
-	public QueueStackModus(ModusType<? extends QueueStackModus> type, PlayerSavedData savedData, LogicalSide side)
+	public QueueStackModus(ModusType<? extends QueueStackModus> type, LogicalSide side)
 	{
-		super(type, savedData, side);
+		super(type, side);
 	}
 	
 	@Override

--- a/src/main/java/com/mraof/minestuck/inventory/captchalogue/SetModus.java
+++ b/src/main/java/com/mraof/minestuck/inventory/captchalogue/SetModus.java
@@ -1,9 +1,8 @@
 package com.mraof.minestuck.inventory.captchalogue;
 
 import com.mraof.minestuck.MinestuckConfig;
-import com.mraof.minestuck.item.MSItems;
 import com.mraof.minestuck.alchemy.AlchemyHelper;
-import com.mraof.minestuck.player.PlayerSavedData;
+import com.mraof.minestuck.item.MSItems;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
@@ -22,9 +21,9 @@ public class SetModus extends Modus
 	protected boolean changed;
 	protected NonNullList<ItemStack> items;
 	
-	public SetModus(ModusType<? extends SetModus> type, PlayerSavedData savedData, LogicalSide side)
+	public SetModus(ModusType<? extends SetModus> type, LogicalSide side)
 	{
-		super(type, savedData, side);
+		super(type, side);
 	}
 	
 	@Override

--- a/src/main/java/com/mraof/minestuck/inventory/captchalogue/StackModus.java
+++ b/src/main/java/com/mraof/minestuck/inventory/captchalogue/StackModus.java
@@ -1,9 +1,8 @@
 package com.mraof.minestuck.inventory.captchalogue;
 
 import com.mraof.minestuck.MinestuckConfig;
-import com.mraof.minestuck.item.MSItems;
 import com.mraof.minestuck.alchemy.AlchemyHelper;
-import com.mraof.minestuck.player.PlayerSavedData;
+import com.mraof.minestuck.item.MSItems;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
@@ -23,9 +22,9 @@ public class StackModus extends Modus
 	protected boolean changed;
 	protected NonNullList<ItemStack> items;
 	
-	public StackModus(ModusType<? extends StackModus> type, PlayerSavedData savedData, LogicalSide side)
+	public StackModus(ModusType<? extends StackModus> type, LogicalSide side)
 	{
-		super(type, savedData, side);
+		super(type, side);
 	}
 	
 	@Override

--- a/src/main/java/com/mraof/minestuck/inventory/captchalogue/TreeModus.java
+++ b/src/main/java/com/mraof/minestuck/inventory/captchalogue/TreeModus.java
@@ -2,9 +2,8 @@ package com.mraof.minestuck.inventory.captchalogue;
 
 import com.mraof.minestuck.MinestuckConfig;
 import com.mraof.minestuck.advancements.MSCriteriaTriggers;
-import com.mraof.minestuck.item.MSItems;
 import com.mraof.minestuck.alchemy.AlchemyHelper;
-import com.mraof.minestuck.player.PlayerSavedData;
+import com.mraof.minestuck.item.MSItems;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
@@ -23,9 +22,9 @@ public class TreeModus extends Modus
 	public int size;
 	public boolean autoBalance = true;
 	
-	public TreeModus(ModusType<? extends TreeModus> type, PlayerSavedData savedData, LogicalSide side)
+	public TreeModus(ModusType<? extends TreeModus> type, LogicalSide side)
 	{
-		super(type, savedData, side);
+		super(type, side);
 	}
 	
 	@Override

--- a/src/main/java/com/mraof/minestuck/player/ClientPlayerData.java
+++ b/src/main/java/com/mraof/minestuck/player/ClientPlayerData.java
@@ -13,6 +13,7 @@ import com.mraof.minestuck.util.ColorHandler;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.common.Mod;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -140,7 +141,7 @@ public final class ClientPlayerData
 	
 	public static void handleDataPacket(ModusDataPacket packet)
 	{
-		modus = CaptchaDeckHandler.readFromNBT(packet.nbt(), null);
+		modus = CaptchaDeckHandler.readFromNBT(packet.nbt(), LogicalSide.CLIENT);
 		if(modus != null)
 			MSScreenFactories.updateSylladexScreen();
 		else LOGGER.debug("Player lost their modus after update packet");

--- a/src/main/java/com/mraof/minestuck/player/Echeladder.java
+++ b/src/main/java/com/mraof/minestuck/player/Echeladder.java
@@ -109,7 +109,6 @@ public class Echeladder
 				boondollarsGained += BOONDOLLARS[Math.min(rung, BOONDOLLARS.length - 1)];
 				exp -= (expReq - progress);
 				progress = 0;
-				savedData.setDirty();
 				expReq = getRungProgressReq();
 				if(rung >= topRung)
 					break increment;
@@ -120,7 +119,6 @@ public class Echeladder
 			if(exp >= 1)
 			{
 				progress += exp;
-				savedData.setDirty();
 				LOGGER.debug("Added remainder exp to progress, which is now at {}", progress);
 			} else
 				LOGGER.debug("Remaining exp {} is below 1, and will therefore be ignored", exp);
@@ -158,7 +156,6 @@ public class Echeladder
 		if(!usedBonuses.contains(type))
 		{
 			usedBonuses.add(type);
-			savedData.setDirty();
 			increaseProgress(type.getBonus());
 		}
 	}
@@ -271,7 +268,6 @@ public class Echeladder
 		
 		if(prevProgress != this.progress || prevRung != this.rung)
 		{
-			savedData.setDirty();
 			ServerPlayer player = identifier.getPlayer(savedData.mcServer);
 			if(player != null && (MinestuckConfig.SERVER.echeladderProgress.get() || prevRung != this.rung))
 			{

--- a/src/main/java/com/mraof/minestuck/player/GristCache.java
+++ b/src/main/java/com/mraof/minestuck/player/GristCache.java
@@ -202,7 +202,6 @@ public final class GristCache
 	public void set(NonNegativeGristSet cache)
 	{
 		gristSet = cache.asImmutable();
-		data.markDirty();
 		data.gristCache.sendPacket(data.getPlayer());
 	}
 	

--- a/src/main/java/com/mraof/minestuck/player/PlayerData.java
+++ b/src/main/java/com/mraof/minestuck/player/PlayerData.java
@@ -18,6 +18,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.common.Mod;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -95,7 +96,7 @@ public final class PlayerData
 		
 		if (nbt.contains("modus"))
 		{
-			this.modus = CaptchaDeckHandler.readFromNBT(nbt.getCompound("modus"), savedData);
+			this.modus = CaptchaDeckHandler.readFromNBT(nbt.getCompound("modus"), LogicalSide.SERVER);
 			givenModus = true;
 		}
 		else givenModus = nbt.getBoolean("given_modus");
@@ -149,11 +150,6 @@ public final class PlayerData
 		return nbt;
 	}
 	
-	void markDirty()
-	{
-		savedData.setDirty();
-	}
-	
 	public Echeladder getEcheladder()
 	{
 		return echeladder;
@@ -169,7 +165,6 @@ public final class PlayerData
 		if(SburbHandler.canSelectColor(identifier, savedData.mcServer) && this.color != color)
 		{
 			this.color = color;
-			markDirty();
 			
 			sendColor(getPlayer(), false);
 		}
@@ -187,7 +182,6 @@ public final class PlayerData
 			this.modus = modus;
 			if(modus != null)
 				setGivenModus();
-			markDirty();
 			ServerPlayer player = this.getPlayer();
 			if(player != null)
 				MSPacketHandler.sendToPlayer(ModusDataPacket.create(modus), player);
@@ -201,11 +195,7 @@ public final class PlayerData
 	
 	private void setGivenModus()
 	{
-		if(!givenModus)
-		{
-			givenModus = true;
-			markDirty();
-		}
+		givenModus = true;
 	}
 	public double getGutterMultipler()
 	{
@@ -216,7 +206,6 @@ public final class PlayerData
 		if(amount < 0)
 			throw new IllegalArgumentException("Multiplier amount may not be negative.");
 		gutterMultiplier += amount;
-		markDirty();
 	}
 	
 	
@@ -232,7 +221,6 @@ public final class PlayerData
 		else if(amount > 0)
 		{
 			boondollars += amount;
-			markDirty();
 			sendBoondollars(getPlayer());
 		}
 	}
@@ -247,7 +235,6 @@ public final class PlayerData
 				throw new IllegalStateException("Can't go to negative boondollars");
 			
 			boondollars -= amount;
-			markDirty();
 			sendBoondollars(getPlayer());
 		}
 	}
@@ -270,7 +257,6 @@ public final class PlayerData
 		else if(amount != boondollars)
 		{
 			boondollars = amount;
-			markDirty();
 			sendBoondollars(getPlayer());
 		}
 	}
@@ -288,7 +274,6 @@ public final class PlayerData
 		if(newRep != oldRep)
 		{
 			consortReputation.put(dim.location(), newRep);
-			markDirty();
 			sendConsortReputation(getPlayer());
 		}
 	}
@@ -308,7 +293,6 @@ public final class PlayerData
 		if(title == null)
 		{
 			title = Objects.requireNonNull(newTitle);
-			markDirty();
 			sendTitle(getPlayer());
 		} else throw new IllegalStateException("Can't set title for player "+ identifier.getUsername()+" because they already have one");
 	}
@@ -320,11 +304,7 @@ public final class PlayerData
 	
 	public void effectToggle(boolean toggle)
 	{
-		if(effectToggle != toggle)
-		{
-			effectToggle = toggle;
-			markDirty();
-		}
+		effectToggle = toggle;
 	}
 	
 	private void tryGiveStartingModus(ServerPlayer player)
@@ -341,7 +321,7 @@ public final class PlayerData
 			return;
 		}
 		
-		Modus modus = type.createServerSide(savedData);
+		Modus modus = type.createServerSide();
 		if(modus != null)
 		{
 			modus.initModus(null, player, null, MinestuckConfig.SERVER.initialModusSize.get());

--- a/src/main/java/com/mraof/minestuck/player/PlayerData.java
+++ b/src/main/java/com/mraof/minestuck/player/PlayerData.java
@@ -13,6 +13,7 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
@@ -58,7 +59,7 @@ public final class PlayerData
 	@Nonnull
 	final PlayerIdentifier identifier;
 	
-	private final PlayerSavedData savedData;
+	private final MinecraftServer mcServer;
 	private final Echeladder echeladder;
 	private int color = ColorHandler.DEFAULT_COLOR;
 	
@@ -75,21 +76,21 @@ public final class PlayerData
 	
 	private boolean hasLoggedIn;
 	
-	PlayerData(PlayerSavedData savedData, @Nonnull PlayerIdentifier player)
+	PlayerData(MinecraftServer mcServer, @Nonnull PlayerIdentifier player)
 	{
-		this.savedData = savedData;
+		this.mcServer = mcServer;
 		this.identifier = player;
-		echeladder = new Echeladder(savedData, player);
-		gristCache = new GristCache(this, savedData.mcServer);
+		echeladder = new Echeladder(mcServer, player);
+		gristCache = new GristCache(this, mcServer);
 		hasLoggedIn = false;
 	}
 	
-	PlayerData(PlayerSavedData savedData, CompoundTag nbt)
+	PlayerData(MinecraftServer mcServer, CompoundTag nbt)
 	{
-		this.savedData = savedData;
+		this.mcServer = mcServer;
 		this.identifier = IdentifierHandler.load(nbt, "player");
 		
-		echeladder = new Echeladder(savedData, identifier);
+		echeladder = new Echeladder(mcServer, identifier);
 		echeladder.loadEcheladder(nbt);
 		if (nbt.contains("color"))
 			this.color = nbt.getInt("color");
@@ -102,7 +103,7 @@ public final class PlayerData
 		else givenModus = nbt.getBoolean("given_modus");
 		boondollars = nbt.getLong("boondollars");
 		
-		gristCache = new GristCache(this, savedData.mcServer);
+		gristCache = new GristCache(this, mcServer);
 		gristCache.read(nbt);
 		
 		ListTag list = nbt.getList("consort_reputation", Tag.TAG_COMPOUND);
@@ -162,7 +163,7 @@ public final class PlayerData
 	
 	public void trySetColor(int color)
 	{
-		if(SburbHandler.canSelectColor(identifier, savedData.mcServer) && this.color != color)
+		if(SburbHandler.canSelectColor(identifier, mcServer) && this.color != color)
 		{
 			this.color = color;
 			
@@ -389,6 +390,6 @@ public final class PlayerData
 	@Nullable
 	ServerPlayer getPlayer()
 	{
-		return identifier.getPlayer(savedData.mcServer);
+		return identifier.getPlayer(mcServer);
 	}
 }

--- a/src/main/java/com/mraof/minestuck/player/PlayerSavedData.java
+++ b/src/main/java/com/mraof/minestuck/player/PlayerSavedData.java
@@ -105,8 +105,15 @@ public final class PlayerSavedData extends SavedData
 		{
 			PlayerData data = new PlayerData(this, player);
 			dataMap.put(player, data);
-			setDirty();
 		}
 		return dataMap.get(player);
+	}
+	
+	@Override
+	public boolean isDirty()
+	{
+		// Always save player data. The number of subcomponents (such as the modus, echeladder, grist cache etc)
+		// makes this preferable to marking the data dirty every time something changes in any of these subcomponents.
+		return true;
 	}
 }

--- a/src/main/java/com/mraof/minestuck/player/PlayerSavedData.java
+++ b/src/main/java/com/mraof/minestuck/player/PlayerSavedData.java
@@ -73,7 +73,7 @@ public final class PlayerSavedData extends SavedData
 			CompoundTag dataCompound = list.getCompound(i);
 			try
 			{
-				PlayerData data = new PlayerData(savedData, dataCompound);
+				PlayerData data = new PlayerData(server, dataCompound);
 				savedData.dataMap.put(data.identifier, data);
 			} catch(Exception e)
 			{
@@ -103,7 +103,7 @@ public final class PlayerSavedData extends SavedData
 		Objects.requireNonNull(player);
 		if (!dataMap.containsKey(player))
 		{
-			PlayerData data = new PlayerData(this, player);
+			PlayerData data = new PlayerData(this.mcServer, player);
 			dataMap.put(player, data);
 		}
 		return dataMap.get(player);


### PR DESCRIPTION
Removes some complexity by removing the need to call `PlayerSavedData.setDirty()` when some data changes, leading to removal or replacement of  `PlayerSavedData` fields and parameters.

Normally, instances of `SavedData` use `setDirty()` to signal that some data has changed, and thus only saving when needed rather than every time that the world saves data. However just like with skaianet data, I believe that the complexity of our data makes keeping it and maintaining it not worth it for the performance gain that it might bring. So as with skaianet data, it'll override `isDirty()` to always return true so that it always saves its data.