### PR TITLE
Patches: Fake players injuring underlings crashes server & librarians in overworld getting dimension specific trades crash client on server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Fake players no longer crash the game when injuring underlings
+- Fix a crash from fake players injuring underlings
 
 ## [1.19.2-1.11.0.0] - 2023-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Fix a crash from fake players injuring underlings
+- Fix a crash caused by librarian villagers in the overworld
+
+### Contributors for this release
+
+- kirderf1, Dweblenod
 
 ## [1.19.2-1.11.0.0] - 2023-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fake players no longer crash the game when injuring underlings
+
 ## [1.19.2-1.11.0.0] - 2023-07-22
 
 ### Added

--- a/src/main/java/com/mraof/minestuck/event/ServerEventHandler.java
+++ b/src/main/java/com/mraof/minestuck/event/ServerEventHandler.java
@@ -24,6 +24,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.*;
@@ -142,20 +143,23 @@ public class ServerEventHandler
 	{
 		if(event.getSource().getEntity() != null)
 		{
-			if (event.getSource().getEntity() instanceof ServerPlayer)
+			Entity attacker = event.getSource().getEntity();
+			Entity injured = event.getEntity();
+			
+			if(injured != null)
 			{
-				ServerPlayer player = (ServerPlayer) event.getSource().getEntity();
-				if (event.getEntity() instanceof UnderlingEntity)
-				{    //Increase damage to underling
-					double modifier = PlayerSavedData.getData(player).getEcheladder().getUnderlingDamageModifier();
+				boolean attackerIsRealPlayer = attacker instanceof Player && !(attacker instanceof FakePlayer);
+				
+				if(attackerIsRealPlayer && injured instanceof UnderlingEntity)
+				{
+					//Increase damage to underling
+					double modifier = PlayerSavedData.getData((ServerPlayer) attacker).getEcheladder().getUnderlingDamageModifier();
 					event.setAmount((float) (event.getAmount() * modifier));
-				}
-			}
-			else if (event.getEntity() instanceof ServerPlayer && event.getSource().getEntity() instanceof UnderlingEntity)
-			{    //Decrease damage to player
-				ServerPlayer player = (ServerPlayer) event.getEntity();
+				} else if (injured instanceof ServerPlayer player && attacker instanceof UnderlingEntity)
+				{    //Decrease damage to player
 					double modifier = PlayerSavedData.getData(player).getEcheladder().getUnderlingProtectionModifier();
 					event.setAmount((float) (event.getAmount() * modifier));
+				}
 			}
 		}
 	}

--- a/src/main/java/com/mraof/minestuck/event/ServerEventHandler.java
+++ b/src/main/java/com/mraof/minestuck/event/ServerEventHandler.java
@@ -148,7 +148,7 @@ public class ServerEventHandler
 			
 			if(injured != null)
 			{
-				boolean attackerIsRealPlayer = attacker instanceof Player && !(attacker instanceof FakePlayer);
+				boolean attackerIsRealPlayer = attacker instanceof ServerPlayer && !(attacker instanceof FakePlayer);
 				
 				if(attackerIsRealPlayer && injured instanceof UnderlingEntity)
 				{

--- a/src/main/java/com/mraof/minestuck/event/ServerEventHandler.java
+++ b/src/main/java/com/mraof/minestuck/event/ServerEventHandler.java
@@ -155,7 +155,7 @@ public class ServerEventHandler
 					//Increase damage to underling
 					double modifier = PlayerSavedData.getData((ServerPlayer) attacker).getEcheladder().getUnderlingDamageModifier();
 					event.setAmount((float) (event.getAmount() * modifier));
-				} else if (injured instanceof ServerPlayer player && attacker instanceof UnderlingEntity)
+				} else if (injured instanceof ServerPlayer player && !(injured instanceof FakePlayer) && attacker instanceof UnderlingEntity)
 				{    //Decrease damage to player
 					double modifier = PlayerSavedData.getData(player).getEcheladder().getUnderlingProtectionModifier();
 					event.setAmount((float) (event.getAmount() * modifier));

--- a/src/main/java/com/mraof/minestuck/event/ServerEventHandler.java
+++ b/src/main/java/com/mraof/minestuck/event/ServerEventHandler.java
@@ -149,15 +149,17 @@ public class ServerEventHandler
 			if(injured != null)
 			{
 				boolean attackerIsRealPlayer = attacker instanceof ServerPlayer && !(attacker instanceof FakePlayer);
+				boolean injuredIsRealPlayer = injured instanceof ServerPlayer && !(injured instanceof FakePlayer);
 				
 				if(attackerIsRealPlayer && injured instanceof UnderlingEntity)
 				{
 					//Increase damage to underling
 					double modifier = PlayerSavedData.getData((ServerPlayer) attacker).getEcheladder().getUnderlingDamageModifier();
 					event.setAmount((float) (event.getAmount() * modifier));
-				} else if (injured instanceof ServerPlayer player && !(injured instanceof FakePlayer) && attacker instanceof UnderlingEntity)
-				{    //Decrease damage to player
-					double modifier = PlayerSavedData.getData(player).getEcheladder().getUnderlingProtectionModifier();
+				} else if (injuredIsRealPlayer && attacker instanceof UnderlingEntity)
+				{
+					//Decrease damage to player
+					double modifier = PlayerSavedData.getData((ServerPlayer) injured).getEcheladder().getUnderlingProtectionModifier();
 					event.setAmount((float) (event.getAmount() * modifier));
 				}
 			}

--- a/src/main/java/com/mraof/minestuck/world/MSDimensions.java
+++ b/src/main/java/com/mraof/minestuck/world/MSDimensions.java
@@ -13,8 +13,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.fml.common.Mod;
 
-import java.util.Objects;
-
 @Mod.EventBusSubscriber(modid = Minestuck.MOD_ID, bus=Mod.EventBusSubscriber.Bus.FORGE)
 public class MSDimensions
 {
@@ -24,8 +22,10 @@ public class MSDimensions
 	
 	public static boolean isLandDimension(MinecraftServer server, ResourceKey<Level> levelKey)
 	{
-		Objects.requireNonNull(server);
-		return LandTypePair.getNamed(server, levelKey).isPresent();
+		if(server != null)
+			return LandTypePair.getNamed(server, levelKey).isPresent();
+		else
+			return false;
 	}
 	
 	public static boolean isSkaia(ResourceKey<Level> dimension)


### PR DESCRIPTION
Fake players were getting their data from PlayerSavedData checked for underling damage modifier. This fixes that.

Also fixes librarian client side crash on server

Also reorganized the relevant code in ServerEventHandler for legibility