### PR TITLE
Logic gate fix

### DIFF
--- a/src/main/java/com/mraof/minestuck/block/redstone/LogicGateBlock.java
+++ b/src/main/java/com/mraof/minestuck/block/redstone/LogicGateBlock.java
@@ -44,11 +44,10 @@ public class LogicGateBlock extends DiodeBlock
 		
 		return logicOperator.operation.test(leftInputSendingPower, rightInputSendingPower);
 	}
-	/*FIXME
-	@Override*/
+	
 	protected int getAlternateSignalAt(LevelReader level, BlockPos pos, Direction side)
 	{
-		return ((Level) level).getSignal(pos.relative(side), side);
+		return level.getSignal(pos.relative(side), side); //replaces protected method in DiodeBlock of the same name
 	}
 	
 	@Override


### PR DESCRIPTION
As of submitting PR, only removes unused commented out Override and removes unnecessary cast.

Doing testing in game, it doesn't appear to require the protected method in DiodeBlock for our needs and there is no uses of the method in DiodeBlock itself. The boolean logic for each gate type was checked, and powering the back face correctly locks the signal