### PR TITLE
Checking for fake player where PlayerSavedData.getData() is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed multiple sources of crashes involving fake players
+
+### Contributors for this release
+
+- Dweblenod
+
 ## [1.19.2-1.11.0.1] - 2023-10-21
 
 ### Fixed

--- a/src/main/java/com/mraof/minestuck/entity/consort/ConsortEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/consort/ConsortEntity.java
@@ -9,6 +9,7 @@ import com.mraof.minestuck.entity.animation.MobAnimation;
 import com.mraof.minestuck.inventory.ConsortMerchantInventory;
 import com.mraof.minestuck.inventory.ConsortMerchantMenu;
 import com.mraof.minestuck.player.IdentifierHandler;
+import com.mraof.minestuck.player.PlayerData;
 import com.mraof.minestuck.player.PlayerIdentifier;
 import com.mraof.minestuck.util.AnimationControllerUtil;
 import com.mraof.minestuck.player.PlayerSavedData;
@@ -134,27 +135,32 @@ public class ConsortEntity extends AnimatedPathfinderMob implements MenuProvider
 	{
 		if(this.isAlive() && !player.isShiftKeyDown() && eventTimer < 0)
 		{
-			if(!level.isClientSide && player instanceof ServerPlayer serverPlayer && PlayerSavedData.getData(serverPlayer).getConsortReputation(homeDimension) > -1000)
+			if(!level.isClientSide && player instanceof ServerPlayer serverPlayer)
 			{
-				if(message == null)
-				{
-					message = ConsortDialogue.getRandomMessage(this, hasHadMessage);
-					hasHadMessage = true;
-				}
+				PlayerData playerData = PlayerSavedData.getData(serverPlayer);
 				
-				checkMessageData();
-				
-				try
+				if(playerData != null && playerData.getConsortReputation(homeDimension) > -1000)
 				{
-					Component text = message.getMessage(this, serverPlayer);
-					if(text != null)
-						player.sendSystemMessage(text);
-					handleConsortRepFromTalking(serverPlayer);
-					setCurrentAnimation(TALK_ANIMATION);
-					MSCriteriaTriggers.CONSORT_TALK.trigger(serverPlayer, message.getString(), this);
-				} catch(Exception e)
-				{
-					LOGGER.error("Got exception when getting dialogue message for consort for player {}.", serverPlayer.getGameProfile().getName(), e);
+					if(message == null)
+					{
+						message = ConsortDialogue.getRandomMessage(this, hasHadMessage);
+						hasHadMessage = true;
+					}
+					
+					checkMessageData();
+					
+					try
+					{
+						Component text = message.getMessage(this, serverPlayer);
+						if(text != null)
+							player.sendSystemMessage(text);
+						handleConsortRepFromTalking(serverPlayer);
+						setCurrentAnimation(TALK_ANIMATION);
+						MSCriteriaTriggers.CONSORT_TALK.trigger(serverPlayer, message.getString(), this);
+					} catch(Exception e)
+					{
+						LOGGER.error("Got exception when getting dialogue message for consort for player {}.", serverPlayer.getGameProfile().getName(), e);
+					}
 				}
 			}
 			
@@ -347,7 +353,7 @@ public class ConsortEntity extends AnimatedPathfinderMob implements MenuProvider
 	@Override
 	public boolean skipAttackInteraction(Entity entityIn)
 	{
-		if(entityIn instanceof ServerPlayer player)
+		if(!(entityIn instanceof FakePlayer) && entityIn instanceof ServerPlayer player)
 			PlayerSavedData.getData(player).addConsortReputation(-5, homeDimension);
 		return super.skipAttackInteraction(entityIn);
 	}

--- a/src/main/java/com/mraof/minestuck/entity/underling/ImpEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/underling/ImpEntity.java
@@ -21,6 +21,7 @@ import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.FakePlayer;
 import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.PlayState;
 import software.bernie.geckolib3.core.builder.AnimationBuilder;
@@ -107,7 +108,7 @@ public class ImpEntity extends UnderlingEntity implements IAnimatable
 	protected boolean isAppropriateTarget(LivingEntity entity)
 	{
 		//imps will not attack players above rung 15 unless an underling is attacked in their presence
-		if(entity instanceof ServerPlayer)
+		if(entity instanceof ServerPlayer && !(entity instanceof FakePlayer))
 		{
 			return PlayerSavedData.getData((ServerPlayer) entity).getEcheladder().getRung() < 16;
 		}

--- a/src/main/java/com/mraof/minestuck/event/ServerEventHandler.java
+++ b/src/main/java/com/mraof/minestuck/event/ServerEventHandler.java
@@ -178,7 +178,7 @@ public class ServerEventHandler
 	@SubscribeEvent(priority = EventPriority.NORMAL, receiveCanceled = false)
 	public static void onPlayerInjured(LivingHurtEvent event)
 	{
-		if(event.getEntity() instanceof Player injuredPlayer)
+		if(event.getEntity() instanceof Player injuredPlayer && !(injuredPlayer instanceof FakePlayer))
 		{
 			Title title = PlayerSavedData.getData((ServerPlayer) injuredPlayer).getTitle();
 			boolean isDoom = title != null && title.getHeroAspect() == EnumAspect.DOOM;
@@ -243,9 +243,13 @@ public class ServerEventHandler
 	@SubscribeEvent(priority=EventPriority.LOW, receiveCanceled=false)
 	public static void onServerChat(ServerChatEvent event)
 	{
-		Modus modus = PlayerSavedData.getData(event.getPlayer()).getModus();
-		if(modus instanceof HashMapModus)
-			((HashMapModus) modus).onChatMessage(event.getPlayer(), event.getMessage().getString());
+		ServerPlayer player = event.getPlayer();
+		if(!(player instanceof FakePlayer))
+		{
+			Modus modus = PlayerSavedData.getData(player).getModus();
+			if(modus instanceof HashMapModus)
+				((HashMapModus) modus).onChatMessage(event.getPlayer(), event.getMessage().getString());
+		}
 	}
 	
 	@SubscribeEvent
@@ -258,7 +262,7 @@ public class ServerEventHandler
 	@SubscribeEvent
 	public static void onPlayerTickEvent(TickEvent.PlayerTickEvent event)
 	{
-		if(!event.player.level.isClientSide)
+		if(!event.player.level.isClientSide && !(event.player instanceof FakePlayer))
 		{
 			PlayerData data = PlayerSavedData.getData((ServerPlayer) event.player);
 			if(data.getTitle() != null)

--- a/src/main/java/com/mraof/minestuck/item/BoondollarsItem.java
+++ b/src/main/java/com/mraof/minestuck/item/BoondollarsItem.java
@@ -14,6 +14,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.FakePlayer;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -28,7 +29,7 @@ public class BoondollarsItem extends Item
 	@Override
 	public InteractionResultHolder<ItemStack> use(Level level, Player playerIn, InteractionHand handIn)
 	{
-		if(!level.isClientSide)
+		if(!level.isClientSide && !(playerIn instanceof FakePlayer))
 		{
 			PlayerSavedData.getData((ServerPlayer) playerIn).addBoondollars(getCount(playerIn.getItemInHand(handIn)));
 		}

--- a/src/main/java/com/mraof/minestuck/item/GutterBallItem.java
+++ b/src/main/java/com/mraof/minestuck/item/GutterBallItem.java
@@ -15,6 +15,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.FakePlayer;
 import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -38,7 +39,7 @@ public class GutterBallItem extends Item
 		itemStack.shrink(1);
 		player.displayClientMessage(Component.translatable(MINOR_INCREASE).withStyle(ChatFormatting.BOLD), true);
 		
-		if(player instanceof ServerPlayer serverPlayer)
+		if(player instanceof ServerPlayer serverPlayer && !(player instanceof FakePlayer))
 		{
 			PlayerSavedData.getData(serverPlayer).addGutterMultiplier(0.2);
 		}

--- a/src/main/java/com/mraof/minestuck/item/GutterThumbDriveItem.java
+++ b/src/main/java/com/mraof/minestuck/item/GutterThumbDriveItem.java
@@ -17,6 +17,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.FakePlayer;
 import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -47,7 +48,7 @@ public class GutterThumbDriveItem extends Item
 			itemStack.shrink(1);
 			player.displayClientMessage(Component.translatable(GREATER_INCREASE).withStyle(ChatFormatting.BOLD), true);
 			
-			if(player instanceof ServerPlayer serverPlayer)
+			if(player instanceof ServerPlayer serverPlayer && !(player instanceof FakePlayer))
 			{
 				PlayerSavedData.getData(serverPlayer).addGutterMultiplier(2.0);
 			}

--- a/src/main/java/com/mraof/minestuck/item/weapon/InventoryTickEffect.java
+++ b/src/main/java/com/mraof/minestuck/item/weapon/InventoryTickEffect.java
@@ -13,6 +13,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.FakePlayer;
 
 import java.util.function.Supplier;
 
@@ -40,7 +41,7 @@ public interface InventoryTickEffect
 	static InventoryTickEffect passiveAspectEffect(EnumAspect aspect, Supplier<MobEffectInstance> effect)
 	{
 		return (stack, worldIn, entityIn, itemSlot, isSelected) -> {
-			if(isSelected && entityIn instanceof ServerPlayer player)
+			if(isSelected && entityIn instanceof ServerPlayer player && !(entityIn instanceof FakePlayer))
 			{
 				Title title = PlayerSavedData.getData(player).getTitle();
 				if(title != null && title.getHeroAspect() == aspect)

--- a/src/main/java/com/mraof/minestuck/item/weapon/MagicAOERightClickEffect.java
+++ b/src/main/java/com/mraof/minestuck/item/weapon/MagicAOERightClickEffect.java
@@ -20,6 +20,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.network.PacketDistributor;
 
 import javax.annotation.Nullable;
@@ -126,9 +127,13 @@ public class MagicAOERightClickEffect implements ItemRightClickEffect
 	
 	protected float calculateDamage(ServerPlayer player, LivingEntity target, int damage)
 	{
-		int playerRung = PlayerSavedData.getData(player).getEcheladder().getRung();
-		
-		//damage increase from rung is higher against underlings
-		return damage + (target instanceof UnderlingEntity ? playerRung / 5F : playerRung / 10F);
+		if(!(player instanceof FakePlayer))
+		{
+			int playerRung = PlayerSavedData.getData(player).getEcheladder().getRung();
+			
+			//damage increase from rung is higher against underlings
+			return damage + (target instanceof UnderlingEntity ? playerRung / 5F : playerRung / 10F);
+		} else
+			return damage;
 	}
 }

--- a/src/main/java/com/mraof/minestuck/item/weapon/MagicRangedRightClickEffect.java
+++ b/src/main/java/com/mraof/minestuck/item/weapon/MagicRangedRightClickEffect.java
@@ -25,6 +25,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.network.PacketDistributor;
 
 import javax.annotation.Nullable;
@@ -144,10 +145,14 @@ public class MagicRangedRightClickEffect implements ItemRightClickEffect
 	
 	protected float calculateDamage(ServerPlayer player, LivingEntity target, int damage)
 	{
-		int playerRung = PlayerSavedData.getData(player).getEcheladder().getRung();
-		
-		//damage increase from rung is higher against underlings
-		return damage + (target instanceof UnderlingEntity ? playerRung / 5F : playerRung / 10F);
+		if(!(player instanceof FakePlayer))
+		{
+			int playerRung = PlayerSavedData.getData(player).getEcheladder().getRung();
+			
+			//damage increase from rung is higher against underlings
+			return damage + (target instanceof UnderlingEntity ? playerRung / 5F : playerRung / 10F);
+		} else
+			return damage;
 	}
 	
 	private static class SbahjMagicEffect extends MagicRangedRightClickEffect

--- a/src/main/java/com/mraof/minestuck/item/weapon/OnHitEffect.java
+++ b/src/main/java/com/mraof/minestuck/item/weapon/OnHitEffect.java
@@ -38,6 +38,7 @@ import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.util.FakePlayer;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -238,7 +239,7 @@ public interface OnHitEffect
 			DamageSource source;
 			float damage = additionalDamage * 3.3F;
 			
-			if(attacker instanceof ServerPlayer serverPlayer)
+			if(attacker instanceof ServerPlayer serverPlayer && !(attacker instanceof FakePlayer))
 			{
 				source = DamageSource.playerAttack(serverPlayer);
 				Title title = PlayerSavedData.getData(serverPlayer).getTitle();
@@ -381,7 +382,7 @@ public interface OnHitEffect
 	static OnHitEffect requireAspect(EnumAspect aspect, OnHitEffect effect)
 	{
 		return (stack, target, attacker) -> {
-			if(attacker instanceof ServerPlayer player)
+			if(attacker instanceof ServerPlayer player && !(attacker instanceof FakePlayer))
 			{
 				Title title = PlayerSavedData.getData(player).getTitle();
 				

--- a/src/main/java/com/mraof/minestuck/item/weapon/PropelEffect.java
+++ b/src/main/java/com/mraof/minestuck/item/weapon/PropelEffect.java
@@ -14,6 +14,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.util.FakePlayer;
 
 public class PropelEffect implements ItemRightClickEffect
 {
@@ -44,6 +45,9 @@ public class PropelEffect implements ItemRightClickEffect
 	
 	void propelAction(Player player, ItemStack stack, double velocity, InteractionHand hand)
 	{
+		if(player instanceof FakePlayer)
+			return;
+		
 		Title title = null;
 		if(player.level.isClientSide)
 		{

--- a/src/main/java/com/mraof/minestuck/item/weapon/projectiles/ReturningProjectileWeaponItem.java
+++ b/src/main/java/com/mraof/minestuck/item/weapon/projectiles/ReturningProjectileWeaponItem.java
@@ -15,6 +15,7 @@ import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.FakePlayer;
 
 public class ReturningProjectileWeaponItem extends ConsumableProjectileWeaponItem
 {
@@ -33,7 +34,7 @@ public class ReturningProjectileWeaponItem extends ConsumableProjectileWeaponIte
 		
 		level.playSound(null, playerIn.getX(), playerIn.getY(), playerIn.getZ(), MSSoundEvents.ITEM_PROJECTILE_THROW.get(), SoundSource.PLAYERS, 1.0F, 1.2F);
 		
-		if(!level.isClientSide)
+		if(!level.isClientSide && !(playerIn instanceof FakePlayer))
 		{
 			boolean noBlockCollision = false;
 			Title title = PlayerSavedData.getData((ServerPlayer) playerIn).getTitle();

--- a/src/main/java/com/mraof/minestuck/player/IdentifierHandler.java
+++ b/src/main/java/com/mraof/minestuck/player/IdentifierHandler.java
@@ -10,6 +10,7 @@ import net.minecraftforge.common.UsernameCache;
 import net.minecraftforge.common.util.FakePlayer;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -28,6 +29,7 @@ public class IdentifierHandler
 	private static int nextIdentifierId;
 	private static int fakePlayerIndex = 0;
 	
+	@Nullable
 	public static PlayerIdentifier encode(Player player)
 	{
 		if(player instanceof FakePlayer || player.getGameProfile() == null)

--- a/src/main/java/com/mraof/minestuck/player/PlayerSavedData.java
+++ b/src/main/java/com/mraof/minestuck/player/PlayerSavedData.java
@@ -100,13 +100,17 @@ public final class PlayerSavedData extends SavedData
 	
 	public PlayerData getData(PlayerIdentifier player)
 	{
-		Objects.requireNonNull(player);
-		if (!dataMap.containsKey(player))
+		if(player != null)
 		{
-			PlayerData data = new PlayerData(this, player);
-			dataMap.put(player, data);
-			setDirty();
+			if (!dataMap.containsKey(player))
+			{
+				PlayerData data = new PlayerData(this, player);
+				dataMap.put(player, data);
+				setDirty();
+			}
+			return dataMap.get(player);
 		}
-		return dataMap.get(player);
+		else
+			return null;
 	}
 }

--- a/src/main/java/com/mraof/minestuck/player/PlayerSavedData.java
+++ b/src/main/java/com/mraof/minestuck/player/PlayerSavedData.java
@@ -1,6 +1,7 @@
 package com.mraof.minestuck.player;
 
 import com.mraof.minestuck.Minestuck;
+import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -13,6 +14,8 @@ import net.minecraft.world.level.storage.DimensionDataStorage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -22,6 +25,8 @@ import java.util.Objects;
  * This class is for server-side use only.
  * @author kirderf1
  */
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public final class PlayerSavedData extends SavedData
 {
 	private static final Logger LOGGER = LogManager.getLogger();
@@ -82,10 +87,14 @@ public final class PlayerSavedData extends SavedData
 		}
 		return savedData;
 	}
-
+	
+	@Nullable
 	public static PlayerData getData(ServerPlayer player)
 	{
-		return get(player.server).getData(IdentifierHandler.encode(player));
+		PlayerIdentifier identifier = IdentifierHandler.encode(player);
+		if(identifier == null)
+			return null;
+		return get(player.server).getData(identifier);
 	}
 	
 	public static PlayerData getData(PlayerIdentifier player, Level level)
@@ -100,17 +109,13 @@ public final class PlayerSavedData extends SavedData
 	
 	public PlayerData getData(PlayerIdentifier player)
 	{
-		if(player != null)
+		Objects.requireNonNull(player);
+		if(!dataMap.containsKey(player))
 		{
-			if (!dataMap.containsKey(player))
-			{
-				PlayerData data = new PlayerData(this, player);
-				dataMap.put(player, data);
-				setDirty();
-			}
-			return dataMap.get(player);
+			PlayerData data = new PlayerData(this, player);
+			dataMap.put(player, data);
+			setDirty();
 		}
-		else
-			return null;
+		return dataMap.get(player);
 	}
 }


### PR DESCRIPTION
Many of the places where PlayerSavedData.getData() was called did not account for a FakePlayer entity, which resulted in server side crashes when the game tries to get information such as echeladder rung/consort reputation/grist cache.