### PR TITLE
Contribution guidelines file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+
+When making a pull request, ensure that the relevant parties are credited.
+
+With code changes, it is assumed that the commit author made those changes unless otherwise stated.
+But for any assets, such as textures, sound files or models, please explicitly write out who the authors of these files are, even if you who are making the pull request is the author of the asset.
+You can put this in the PR description or in the commit message.
+
+Also, please make sure that you add any player-visible changes to the unreleased section of the [changelog](CHANGELOG.md).
+Also make sure that those who contributed to the pull request are listed as contributors in the unreleased section.


### PR DESCRIPTION
A ready-to-review draft of a contributor guidelines file. It's not much so far, and so the idea is for people to return and add more to it later.