### PR TITLE
Parent model for some similar blocks

### DIFF
--- a/src/main/resources/assets/minestuck/models/block/and_gate_block.json
+++ b/src/main/resources/assets/minestuck/models/block/and_gate_block.json
@@ -1,27 +1,14 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "back": "minestuck:block/logic_gate_back",
-        "right_side": "minestuck:block/logic_gate_right_side",
-        "left_side": "minestuck:block/logic_gate_left_side",
-        "top": "minestuck:block/redstone_machine_block",
-        "bottom": "minestuck:block/redstone_machine_block",
-        "front": "minestuck:block/and_gate",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/logic_gate_back",
+        "south": "minestuck:block/and_gate",
+        "west": "minestuck:block/logic_gate_left_side",
+        "east": "minestuck:block/logic_gate_right_side",
         "particle": "minestuck:block/and_gate"
     },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#top", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#back", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#left_side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#right_side", "cullface": "east" }
-            }
-        }
-    ],
     "display": {
         "gui": {
             "rotation": [30, 45, 0],

--- a/src/main/resources/assets/minestuck/models/block/and_gate_block.json
+++ b/src/main/resources/assets/minestuck/models/block/and_gate_block.json
@@ -1,23 +1,6 @@
 {
-    "parent": "minestuck:block/cube_up_mirrored",
+    "parent": "minestuck:block/logic_gate_cube",
     "textures": {
-        "down": "minestuck:block/redstone_machine_block",
-        "up": "minestuck:block/redstone_machine_block",
-        "north": "minestuck:block/logic_gate_back",
-        "south": "minestuck:block/and_gate",
-        "west": "minestuck:block/logic_gate_left_side",
-        "east": "minestuck:block/logic_gate_right_side",
-        "particle": "minestuck:block/and_gate"
-    },
-    "display": {
-        "gui": {
-            "rotation": [30, 45, 0],
-            "scale": [0.625, 0.625, 0.625]
-        },
-        "fixed": {
-            "rotation": [0, -180, 0],
-            "translation": [0, 0, 0],
-            "scale": [0.5, 0.5, 0.5]
-        }
+        "front": "minestuck:block/and_gate"
     }
 }

--- a/src/main/resources/assets/minestuck/models/block/area_effect_block_powered.json
+++ b/src/main/resources/assets/minestuck/models/block/area_effect_block_powered.json
@@ -1,22 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "front": "minestuck:block/area_effect_block_front_powered",
-        "back": "minestuck:block/area_effect_block_side",
-        "side": "minestuck:block/redstone_machine_block",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/area_effect_block_front_powered",
+        "south": "minestuck:block/area_effect_block_side",
+        "west": "minestuck:block/redstone_machine_block",
+        "east": "minestuck:block/redstone_machine_block",
         "particle": "minestuck:block/area_effect_block_side"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#side", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#back", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/area_effect_block_unpowered.json
+++ b/src/main/resources/assets/minestuck/models/block/area_effect_block_unpowered.json
@@ -1,22 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "front": "minestuck:block/area_effect_block_front_unpowered",
-        "back": "minestuck:block/area_effect_block_side",
-        "side": "minestuck:block/redstone_machine_block",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/area_effect_block_front_unpowered",
+        "south": "minestuck:block/area_effect_block_side",
+        "west": "minestuck:block/redstone_machine_block",
+        "east": "minestuck:block/redstone_machine_block",
         "particle": "minestuck:block/area_effect_block_side"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#side", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#back", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/cube_up_mirrored.json
+++ b/src/main/resources/assets/minestuck/models/block/cube_up_mirrored.json
@@ -1,0 +1,16 @@
+{
+    "parent": "block/block",
+    "elements": [
+        {   "from": [ 0, 0, 0 ],
+            "to": [ 16, 16, 16 ],
+            "faces": {
+                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#down", "cullface": "down" },
+                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#up", "cullface": "up" },
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#north", "cullface": "north" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#south", "cullface": "south" },
+                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#west", "cullface": "west" },
+                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#east", "cullface": "east" }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/minestuck/models/block/grist_collector.json
+++ b/src/main/resources/assets/minestuck/models/block/grist_collector.json
@@ -1,23 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "side": "minestuck:block/grist_collector_side",
-        "left_side": "minestuck:block/grist_collector_left_side",
-        "end": "minestuck:block/grist_collector_top",
-        "front": "minestuck:block/grist_collector_front",
+        "down": "minestuck:block/grist_collector_top",
+        "up": "minestuck:block/grist_collector_top",
+        "north": "minestuck:block/grist_collector_front",
+        "south": "minestuck:block/grist_collector_side",
+        "west": "minestuck:block/grist_collector_left_side",
+        "east": "minestuck:block/grist_collector_side",
         "particle": "minestuck:block/grist_collector_side"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#end", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#end", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#left_side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/logic_gate_cube.json
+++ b/src/main/resources/assets/minestuck/models/block/logic_gate_cube.json
@@ -1,0 +1,23 @@
+{
+    "parent": "minestuck:block/cube_up_mirrored",
+    "textures": {
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/logic_gate_back",
+        "south": "#front",
+        "west": "minestuck:block/logic_gate_left_side",
+        "east": "minestuck:block/logic_gate_right_side",
+        "particle": "#front"
+    },
+    "display": {
+        "gui": {
+            "rotation": [30, 45, 0],
+            "scale": [0.625, 0.625, 0.625]
+        },
+        "fixed": {
+            "rotation": [0, -180, 0],
+            "translation": [0, 0, 0],
+            "scale": [0.5, 0.5, 0.5]
+        }
+    }
+}

--- a/src/main/resources/assets/minestuck/models/block/nand_gate_block.json
+++ b/src/main/resources/assets/minestuck/models/block/nand_gate_block.json
@@ -1,23 +1,6 @@
 {
-    "parent": "minestuck:block/cube_up_mirrored",
+    "parent": "minestuck:block/logic_gate_cube",
     "textures": {
-        "down": "minestuck:block/redstone_machine_block",
-        "up": "minestuck:block/redstone_machine_block",
-        "north": "minestuck:block/logic_gate_back",
-        "south": "minestuck:block/nand_gate",
-        "west": "minestuck:block/logic_gate_left_side",
-        "east": "minestuck:block/logic_gate_right_side",
-        "particle": "minestuck:block/nand_gate"
-    },
-    "display": {
-        "gui": {
-            "rotation": [30, 45, 0],
-            "scale": [0.625, 0.625, 0.625]
-        },
-        "fixed": {
-            "rotation": [0, -180, 0],
-            "translation": [0, 0, 0],
-            "scale": [0.5, 0.5, 0.5]
-        }
+        "front": "minestuck:block/nand_gate"
     }
 }

--- a/src/main/resources/assets/minestuck/models/block/nand_gate_block.json
+++ b/src/main/resources/assets/minestuck/models/block/nand_gate_block.json
@@ -1,27 +1,14 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "back": "minestuck:block/logic_gate_back",
-        "right_side": "minestuck:block/logic_gate_right_side",
-        "left_side": "minestuck:block/logic_gate_left_side",
-        "top": "minestuck:block/redstone_machine_block",
-        "bottom": "minestuck:block/redstone_machine_block",
-        "front": "minestuck:block/nand_gate",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/logic_gate_back",
+        "south": "minestuck:block/nand_gate",
+        "west": "minestuck:block/logic_gate_left_side",
+        "east": "minestuck:block/logic_gate_right_side",
         "particle": "minestuck:block/nand_gate"
     },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#top", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#back", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#left_side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#right_side", "cullface": "east" }
-            }
-        }
-    ],
     "display": {
         "gui": {
             "rotation": [30, 45, 0],

--- a/src/main/resources/assets/minestuck/models/block/nor_gate_block.json
+++ b/src/main/resources/assets/minestuck/models/block/nor_gate_block.json
@@ -1,27 +1,14 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "back": "minestuck:block/logic_gate_back",
-        "right_side": "minestuck:block/logic_gate_right_side",
-        "left_side": "minestuck:block/logic_gate_left_side",
-        "top": "minestuck:block/redstone_machine_block",
-        "bottom": "minestuck:block/redstone_machine_block",
-        "front": "minestuck:block/nor_gate",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/logic_gate_back",
+        "south": "minestuck:block/nor_gate",
+        "west": "minestuck:block/logic_gate_left_side",
+        "east": "minestuck:block/logic_gate_right_side",
         "particle": "minestuck:block/nor_gate"
     },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#top", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#back", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#left_side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#right_side", "cullface": "east" }
-            }
-        }
-    ],
     "display": {
         "gui": {
             "rotation": [30, 45, 0],

--- a/src/main/resources/assets/minestuck/models/block/nor_gate_block.json
+++ b/src/main/resources/assets/minestuck/models/block/nor_gate_block.json
@@ -1,23 +1,6 @@
 {
-    "parent": "minestuck:block/cube_up_mirrored",
+    "parent": "minestuck:block/logic_gate_cube",
     "textures": {
-        "down": "minestuck:block/redstone_machine_block",
-        "up": "minestuck:block/redstone_machine_block",
-        "north": "minestuck:block/logic_gate_back",
-        "south": "minestuck:block/nor_gate",
-        "west": "minestuck:block/logic_gate_left_side",
-        "east": "minestuck:block/logic_gate_right_side",
-        "particle": "minestuck:block/nor_gate"
-    },
-    "display": {
-        "gui": {
-            "rotation": [30, 45, 0],
-            "scale": [0.625, 0.625, 0.625]
-        },
-        "fixed": {
-            "rotation": [0, -180, 0],
-            "translation": [0, 0, 0],
-            "scale": [0.5, 0.5, 0.5]
-        }
+        "front": "minestuck:block/nor_gate"
     }
 }

--- a/src/main/resources/assets/minestuck/models/block/or_gate_block.json
+++ b/src/main/resources/assets/minestuck/models/block/or_gate_block.json
@@ -1,27 +1,14 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "back": "minestuck:block/logic_gate_back",
-        "right_side": "minestuck:block/logic_gate_right_side",
-        "left_side": "minestuck:block/logic_gate_left_side",
-        "top": "minestuck:block/redstone_machine_block",
-        "bottom": "minestuck:block/redstone_machine_block",
-        "front": "minestuck:block/or_gate",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/logic_gate_back",
+        "south": "minestuck:block/or_gate",
+        "west": "minestuck:block/logic_gate_left_side",
+        "east": "minestuck:block/logic_gate_right_side",
         "particle": "minestuck:block/or_gate"
     },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#top", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#back", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#left_side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#right_side", "cullface": "east" }
-            }
-        }
-    ],
     "display": {
         "gui": {
             "rotation": [30, 45, 0],

--- a/src/main/resources/assets/minestuck/models/block/or_gate_block.json
+++ b/src/main/resources/assets/minestuck/models/block/or_gate_block.json
@@ -1,23 +1,6 @@
 {
-    "parent": "minestuck:block/cube_up_mirrored",
+    "parent": "minestuck:block/logic_gate_cube",
     "textures": {
-        "down": "minestuck:block/redstone_machine_block",
-        "up": "minestuck:block/redstone_machine_block",
-        "north": "minestuck:block/logic_gate_back",
-        "south": "minestuck:block/or_gate",
-        "west": "minestuck:block/logic_gate_left_side",
-        "east": "minestuck:block/logic_gate_right_side",
-        "particle": "minestuck:block/or_gate"
-    },
-    "display": {
-        "gui": {
-            "rotation": [30, 45, 0],
-            "scale": [0.625, 0.625, 0.625]
-        },
-        "fixed": {
-            "rotation": [0, -180, 0],
-            "translation": [0, 0, 0],
-            "scale": [0.5, 0.5, 0.5]
-        }
+        "front": "minestuck:block/or_gate"
     }
 }

--- a/src/main/resources/assets/minestuck/models/block/pink_frosted_top_large_cake0.json
+++ b/src/main/resources/assets/minestuck/models/block/pink_frosted_top_large_cake0.json
@@ -1,21 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
         "particle": "minestuck:block/pink_frosted_top_large_cake_side",
-        "bottom": "minestuck:block/large_cake",
-        "top": "minestuck:block/pink_frosted_top_large_cake_top0",
-        "side": "minestuck:block/pink_frosted_top_large_cake_side"
-    },"elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-            "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
-            "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#top", "cullface": "up" },
-            "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "north" },
-            "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
-            "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-            "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+        "down": "minestuck:block/large_cake",
+        "up": "minestuck:block/pink_frosted_top_large_cake_top0",
+        "north": "minestuck:block/pink_frosted_top_large_cake_side",
+        "south": "minestuck:block/pink_frosted_top_large_cake_side",
+        "west": "minestuck:block/pink_frosted_top_large_cake_side",
+        "east": "minestuck:block/pink_frosted_top_large_cake_side"
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/pink_frosted_top_large_cake1.json
+++ b/src/main/resources/assets/minestuck/models/block/pink_frosted_top_large_cake1.json
@@ -1,21 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
         "particle": "minestuck:block/pink_frosted_top_large_cake_side",
-        "bottom": "minestuck:block/large_cake",
-        "top": "minestuck:block/pink_frosted_top_large_cake_top1",
-        "side": "minestuck:block/pink_frosted_top_large_cake_side"
-    },"elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-            "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
-            "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#top", "cullface": "up" },
-            "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "north" },
-            "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
-            "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-            "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+        "down": "minestuck:block/large_cake",
+        "up": "minestuck:block/pink_frosted_top_large_cake_top1",
+        "north": "minestuck:block/pink_frosted_top_large_cake_side",
+        "south": "minestuck:block/pink_frosted_top_large_cake_side",
+        "west": "minestuck:block/pink_frosted_top_large_cake_side",
+        "east": "minestuck:block/pink_frosted_top_large_cake_side"
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/power_hub.json
+++ b/src/main/resources/assets/minestuck/models/block/power_hub.json
@@ -1,23 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "side": "minestuck:block/power_hub_side",
-        "bottom": "minestuck:block/power_hub_bottom",
-        "top": "minestuck:block/power_hub_top",
-        "front": "minestuck:block/power_hub_front",
+        "down": "minestuck:block/power_hub_bottom",
+        "up": "minestuck:block/power_hub_top",
+        "north": "minestuck:block/power_hub_front",
+        "south": "minestuck:block/power_hub_side",
+        "west": "minestuck:block/power_hub_side",
+        "east": "minestuck:block/power_hub_side",
         "particle": "minestuck:block/power_hub_side"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#top", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/redstone_clock_powered.json
+++ b/src/main/resources/assets/minestuck/models/block/redstone_clock_powered.json
@@ -1,21 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "front": "minestuck:block/redstone_clock_powered",
-        "side": "minestuck:block/redstone_clock_side",
+        "down": "minestuck:block/redstone_clock_side",
+        "up": "minestuck:block/redstone_clock_side",
+        "north": "minestuck:block/redstone_clock_powered",
+        "south": "minestuck:block/redstone_clock_side",
+        "west": "minestuck:block/redstone_clock_side",
+        "east": "minestuck:block/redstone_clock_side",
         "particle": "minestuck:block/redstone_clock_side"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#side", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/redstone_clock_unpowered.json
+++ b/src/main/resources/assets/minestuck/models/block/redstone_clock_unpowered.json
@@ -1,21 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "front": "minestuck:block/redstone_clock_unpowered",
-        "side": "minestuck:block/redstone_clock_side",
+        "down": "minestuck:block/redstone_clock_side",
+        "up": "minestuck:block/redstone_clock_side",
+        "north": "minestuck:block/redstone_clock_unpowered",
+        "south": "minestuck:block/redstone_clock_side",
+        "west": "minestuck:block/redstone_clock_side",
+        "east": "minestuck:block/redstone_clock_side",
         "particle": "minestuck:block/redstone_clock_side"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#side", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/remote_comparator_powered.json
+++ b/src/main/resources/assets/minestuck/models/block/remote_comparator_powered.json
@@ -1,22 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "front": "minestuck:block/remote_observer_powered",
-        "side": "minestuck:block/redstone_machine_block",
-        "back": "minestuck:block/rotator_bottom",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/remote_observer_powered",
+        "south": "minestuck:block/rotator_bottom",
+        "west": "minestuck:block/redstone_machine_block",
+        "east": "minestuck:block/redstone_machine_block",
         "particle": "minestuck:block/redstone_machine_block"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#side", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#back", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/remote_comparator_unpowered.json
+++ b/src/main/resources/assets/minestuck/models/block/remote_comparator_unpowered.json
@@ -1,22 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "front": "minestuck:block/remote_observer_unpowered",
-        "side": "minestuck:block/redstone_machine_block",
-        "back": "minestuck:block/rotator_bottom",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/remote_observer_unpowered",
+        "south": "minestuck:block/rotator_bottom",
+        "west": "minestuck:block/redstone_machine_block",
+        "east": "minestuck:block/redstone_machine_block",
         "particle": "minestuck:block/redstone_machine_block"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#side", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#back", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/scarred_shadewood_log.json
+++ b/src/main/resources/assets/minestuck/models/block/scarred_shadewood_log.json
@@ -1,22 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "side": "minestuck:block/shadewood",
-        "end": "minestuck:block/scarred_shadewood_top",
-        "front": "minestuck:block/scarred_shadewood",
+        "down": "minestuck:block/scarred_shadewood_top",
+        "up": "minestuck:block/scarred_shadewood_top",
+        "north": "minestuck:block/scarred_shadewood",
+        "south": "minestuck:block/shadewood",
+        "west": "minestuck:block/shadewood",
+        "east": "minestuck:block/shadewood",
         "particle": "minestuck:block/shadewood"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#end", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#end", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/stripped_scarred_shadewood_log.json
+++ b/src/main/resources/assets/minestuck/models/block/stripped_scarred_shadewood_log.json
@@ -1,23 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "side": "minestuck:block/stripped_shadewood_log",
-        "top": "minestuck:block/stripped_scarred_shadewood_log_top",
-        "bottom": "minestuck:block/stripped_scarred_shadewood_log_top",
-        "front": "minestuck:block/stripped_scarred_shadewood_log",
+        "down": "minestuck:block/stripped_scarred_shadewood_log_top",
+        "up": "minestuck:block/stripped_scarred_shadewood_log_top",
+        "north": "minestuck:block/stripped_scarred_shadewood_log",
+        "south": "minestuck:block/stripped_shadewood_log",
+        "west": "minestuck:block/stripped_shadewood_log",
+        "east": "minestuck:block/stripped_shadewood_log",
         "particle": "minestuck:block/stripped_shadewood_log"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#top", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/trajectory_block_horizontal_powered.json
+++ b/src/main/resources/assets/minestuck/models/block/trajectory_block_horizontal_powered.json
@@ -1,21 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "top": "minestuck:block/trajectory_block_horizontal_top_powered",
-        "side": "minestuck:block/redstone_machine_block",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/redstone_machine_block",
+        "south": "minestuck:block/trajectory_block_horizontal_top_powered",
+        "west": "minestuck:block/redstone_machine_block",
+        "east": "minestuck:block/redstone_machine_block",
         "particle": "minestuck:block/redstone_machine_block"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#side", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#top", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/trajectory_block_horizontal_unpowered.json
+++ b/src/main/resources/assets/minestuck/models/block/trajectory_block_horizontal_unpowered.json
@@ -1,21 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "top": "minestuck:block/trajectory_block_horizontal_top_unpowered",
-        "side": "minestuck:block/redstone_machine_block",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/redstone_machine_block",
+        "south": "minestuck:block/trajectory_block_horizontal_top_unpowered",
+        "west": "minestuck:block/redstone_machine_block",
+        "east": "minestuck:block/redstone_machine_block",
         "particle": "minestuck:block/redstone_machine_block"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#side", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#top", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/wireless_redstone_receiver_powered.json
+++ b/src/main/resources/assets/minestuck/models/block/wireless_redstone_receiver_powered.json
@@ -1,21 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "front": "minestuck:block/wireless_redstone_receiver_front_powered",
-        "side": "minestuck:block/redstone_machine_block",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/wireless_redstone_receiver_front_powered",
+        "south": "minestuck:block/redstone_machine_block",
+        "west": "minestuck:block/redstone_machine_block",
+        "east": "minestuck:block/redstone_machine_block",
         "particle": "minestuck:block/wireless_redstone_receiver_front_powered"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#side", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/wireless_redstone_receiver_unpowered.json
+++ b/src/main/resources/assets/minestuck/models/block/wireless_redstone_receiver_unpowered.json
@@ -1,21 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "front": "minestuck:block/wireless_redstone_receiver_front_unpowered",
-        "side": "minestuck:block/redstone_machine_block",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/wireless_redstone_receiver_front_unpowered",
+        "south": "minestuck:block/redstone_machine_block",
+        "west": "minestuck:block/redstone_machine_block",
+        "east": "minestuck:block/redstone_machine_block",
         "particle": "minestuck:block/wireless_redstone_receiver_front_unpowered"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#side", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/wireless_redstone_transmitter_powered.json
+++ b/src/main/resources/assets/minestuck/models/block/wireless_redstone_transmitter_powered.json
@@ -1,21 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "front": "minestuck:block/wireless_redstone_transmitter_front_powered",
-        "side": "minestuck:block/redstone_machine_block",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/wireless_redstone_transmitter_front_powered",
+        "south": "minestuck:block/redstone_machine_block",
+        "west": "minestuck:block/redstone_machine_block",
+        "east": "minestuck:block/redstone_machine_block",
         "particle": "minestuck:block/wireless_redstone_transmitter_front_powered"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#side", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/wireless_redstone_transmitter_unpowered.json
+++ b/src/main/resources/assets/minestuck/models/block/wireless_redstone_transmitter_unpowered.json
@@ -1,21 +1,12 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "front": "minestuck:block/wireless_redstone_transmitter_front_unpowered",
-        "side": "minestuck:block/redstone_machine_block",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/wireless_redstone_transmitter_front_unpowered",
+        "south": "minestuck:block/redstone_machine_block",
+        "west": "minestuck:block/redstone_machine_block",
+        "east": "minestuck:block/redstone_machine_block",
         "particle": "minestuck:block/wireless_redstone_transmitter_front_unpowered"
-    },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#side", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#side", "cullface": "east" }
-            }
-        }
-    ]
+    }
 }

--- a/src/main/resources/assets/minestuck/models/block/xnor_gate_block.json
+++ b/src/main/resources/assets/minestuck/models/block/xnor_gate_block.json
@@ -1,23 +1,6 @@
 {
-    "parent": "minestuck:block/cube_up_mirrored",
+    "parent": "minestuck:block/logic_gate_cube",
     "textures": {
-        "down": "minestuck:block/redstone_machine_block",
-        "up": "minestuck:block/redstone_machine_block",
-        "north": "minestuck:block/logic_gate_back",
-        "south": "minestuck:block/xnor_gate",
-        "west": "minestuck:block/logic_gate_left_side",
-        "east": "minestuck:block/logic_gate_right_side",
-        "particle": "minestuck:block/xnor_gate"
-    },
-    "display": {
-        "gui": {
-            "rotation": [30, 45, 0],
-            "scale": [0.625, 0.625, 0.625]
-        },
-        "fixed": {
-            "rotation": [0, -180, 0],
-            "translation": [0, 0, 0],
-            "scale": [0.5, 0.5, 0.5]
-        }
+        "front": "minestuck:block/xnor_gate"
     }
 }

--- a/src/main/resources/assets/minestuck/models/block/xnor_gate_block.json
+++ b/src/main/resources/assets/minestuck/models/block/xnor_gate_block.json
@@ -1,27 +1,14 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "back": "minestuck:block/logic_gate_back",
-        "right_side": "minestuck:block/logic_gate_right_side",
-        "left_side": "minestuck:block/logic_gate_left_side",
-        "top": "minestuck:block/redstone_machine_block",
-        "bottom": "minestuck:block/redstone_machine_block",
-        "front": "minestuck:block/xnor_gate",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/logic_gate_back",
+        "south": "minestuck:block/xnor_gate",
+        "west": "minestuck:block/logic_gate_left_side",
+        "east": "minestuck:block/logic_gate_right_side",
         "particle": "minestuck:block/xnor_gate"
     },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#top", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#back", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#left_side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#right_side", "cullface": "east" }
-            }
-        }
-    ],
     "display": {
         "gui": {
             "rotation": [30, 45, 0],

--- a/src/main/resources/assets/minestuck/models/block/xor_gate_block.json
+++ b/src/main/resources/assets/minestuck/models/block/xor_gate_block.json
@@ -1,27 +1,14 @@
 {
-    "parent": "block/block",
+    "parent": "minestuck:block/cube_up_mirrored",
     "textures": {
-        "back": "minestuck:block/logic_gate_back",
-        "right_side": "minestuck:block/logic_gate_right_side",
-        "left_side": "minestuck:block/logic_gate_left_side",
-        "top": "minestuck:block/redstone_machine_block",
-        "bottom": "minestuck:block/redstone_machine_block",
-        "front": "minestuck:block/xor_gate",
+        "down": "minestuck:block/redstone_machine_block",
+        "up": "minestuck:block/redstone_machine_block",
+        "north": "minestuck:block/logic_gate_back",
+        "south": "minestuck:block/xor_gate",
+        "west": "minestuck:block/logic_gate_left_side",
+        "east": "minestuck:block/logic_gate_right_side",
         "particle": "minestuck:block/xor_gate"
     },
-    "elements": [
-        {   "from": [ 0, 0, 0 ],
-            "to": [ 16, 16, 16 ],
-            "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
-                "up":    { "uv": [ 0, 16, 16, 0 ], "texture": "#top", "cullface": "up" },
-                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#back", "cullface": "north" },
-                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#front", "cullface": "south" },
-                "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#left_side", "cullface": "west" },
-                "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#right_side", "cullface": "east" }
-            }
-        }
-    ],
     "display": {
         "gui": {
             "rotation": [30, 45, 0],

--- a/src/main/resources/assets/minestuck/models/block/xor_gate_block.json
+++ b/src/main/resources/assets/minestuck/models/block/xor_gate_block.json
@@ -1,23 +1,6 @@
 {
-    "parent": "minestuck:block/cube_up_mirrored",
+    "parent": "minestuck:block/logic_gate_cube",
     "textures": {
-        "down": "minestuck:block/redstone_machine_block",
-        "up": "minestuck:block/redstone_machine_block",
-        "north": "minestuck:block/logic_gate_back",
-        "south": "minestuck:block/xor_gate",
-        "west": "minestuck:block/logic_gate_left_side",
-        "east": "minestuck:block/logic_gate_right_side",
-        "particle": "minestuck:block/xor_gate"
-    },
-    "display": {
-        "gui": {
-            "rotation": [30, 45, 0],
-            "scale": [0.625, 0.625, 0.625]
-        },
-        "fixed": {
-            "rotation": [0, -180, 0],
-            "translation": [0, 0, 0],
-            "scale": [0.5, 0.5, 0.5]
-        }
+        "front": "minestuck:block/xor_gate"
     }
 }


### PR DESCRIPTION
Extracts some common elements and display data shared between block models to create `cube_up_mirrored.json` and `logic_gate_cube.json`. The block specific models are now a bit more suitable for data generation, the logic gate blocks in particular.

While I wanted to make some more specific models with fewer texture variables, there weren't enough remaining similarities to go by.