### PR TITLE
Stopping milk from curing Creative Shock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Fixed multiple sources of crashes involving fake players
+- Creative Shock effect is no longer cured by drinking milk
 
 ### Contributors for this release
 

--- a/src/main/java/com/mraof/minestuck/effects/CreativeShockEffect.java
+++ b/src/main/java/com/mraof/minestuck/effects/CreativeShockEffect.java
@@ -11,6 +11,7 @@ import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.EnderpearlItem;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -18,6 +19,9 @@ import net.minecraftforge.event.level.ExplosionEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This is an adapted version of Cibernet's code in Minestuck Universe, credit goes to him!
@@ -60,6 +64,12 @@ public class CreativeShockEffect extends MobEffect
 	{
 		if(CreativeShockEffect.doesCreativeShockLimit(player, survivalAmplifierThreshold))
 			player.stopFallFlying();
+	}
+	
+	@Override
+	public List<ItemStack> getCurativeItems()
+	{
+		return new ArrayList<>(); //prevent milk from curing creative shock
 	}
 	
 	@Override

--- a/src/main/java/com/mraof/minestuck/effects/CreativeShockEffect.java
+++ b/src/main/java/com/mraof/minestuck/effects/CreativeShockEffect.java
@@ -20,7 +20,7 @@ import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -69,7 +69,7 @@ public class CreativeShockEffect extends MobEffect
 	@Override
 	public List<ItemStack> getCurativeItems()
 	{
-		return new ArrayList<>(); //prevent milk from curing creative shock
+		return Collections.emptyList(); //prevent milk from curing creative shock
 	}
 	
 	@Override

--- a/src/main/java/com/mraof/minestuck/effects/CreativeShockEffect.java
+++ b/src/main/java/com/mraof/minestuck/effects/CreativeShockEffect.java
@@ -20,7 +20,7 @@ import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -69,7 +69,7 @@ public class CreativeShockEffect extends MobEffect
 	@Override
 	public List<ItemStack> getCurativeItems()
 	{
-		return Collections.emptyList(); //prevent milk from curing creative shock
+		return new ArrayList<>(); //prevent milk from curing creative shock
 	}
 	
 	@Override


### PR DESCRIPTION
As with other potion effects, Creative Shock is removed from players after they drink milk. This functionality is overridden and now there are no items which remove Creative Shock