### PR TITLE
Cruxtruder cruxite changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Updated all grist and vitality gel sprites
 - Tweaked some Rung names
 - New rung-up jingle.
+- cruxtruderIntake config for cruxtruders now false by default, and now start with a value of one if set to true
 
 ### Fixed
 

--- a/src/main/java/com/mraof/minestuck/MinestuckConfig.java
+++ b/src/main/java/com/mraof/minestuck/MinestuckConfig.java
@@ -184,7 +184,7 @@ public class MinestuckConfig
 			puzzleBlockTickRate = builder.comment("How often puzzle/redstone related blocks such as the remote observer tick.")
 					.defineInRange("puzzleBlockTickRate",6,2,10);
 			cruxtruderIntake = builder.comment("If enabled, the regular cruxtruder will require raw cruxite to function, which is inserted through the pipe.")
-					.define("cruxtruderIntake",true);
+					.define("cruxtruderIntake", false);
 			forbiddenWorldsTpz = builder.comment("A list of worlds that you cannot travel to or from using transportalizers.")
 					.define("forbiddenWorldsTpz", new ArrayList<>());
 			forbiddenDimensionTypesTpz = builder.comment("A list of dimension types that you cannot travel to or from using transportalizers.")


### PR DESCRIPTION
Changes it so that the cruxtruder does not require cruxite by default. When it does, it will have one cruxite when first placed down. Also cleans up code and removes inactive, somewhat inappropriate, attempt to retrieve cruxite that has already been stuffed inside.