### PR TITLE
Captchalogue Component blacklist and inital captcha card amount fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Players now cannot captchalogue items if they contain certain nested item components. This replaces the bugged maximum data system introduced in the last update
+
+### Contributors for this release
+
+- medsal15, heartsremedy, caldw3ll, v_sabitron, Dweblenod
+
 ## [1.21.1-1.14.0.0] - 2026-04-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Players now cannot captchalogue items if they contain certain nested item components. This replaces the bugged maximum data system introduced in the last update
 
+### Fixed
+
+- Fixed players starting off with no captcha cards
+
 ### Contributors for this release
 
-- medsal15, heartsremedy, caldw3ll, v_sabitron, Dweblenod
+- Dweblenod
 
 ## [1.21.1-1.14.0.0] - 2026-04-13
 

--- a/src/main/java/com/mraof/minestuck/MinestuckConfig.java
+++ b/src/main/java/com/mraof/minestuck/MinestuckConfig.java
@@ -86,7 +86,7 @@ public class MinestuckConfig
 		//Sylladex
 		public final BooleanValue dropItemsInCards;
 		public final IntValue initialModusSize;
-		public final IntValue captchaComponentSize;
+		public final ConfigValue<List<? extends String>> captchaComponentBlacklist;
 		public final EnumValue<DropMode> sylladexDropMode;
 		public final EnumValue<AvailableOptions> treeModusSetting;
 		public final EnumValue<AvailableOptions> hashmapChatModusSetting;
@@ -149,8 +149,8 @@ public class MinestuckConfig
 					.define("dropItemsInCards", true);
 			initialModusSize = builder.comment("The initial amount of captchalogue cards in your sylladex. The value is capped by the captchalogue_capacity Attribute")
 					.defineInRange("initialModusSize", 5, 0, Integer.MAX_VALUE);
-			captchaComponentSize = builder.comment("The max size of the data in NBT/Components allowed on a card being stored. Captchaloguing items with lots of data can cause crashes.")
-					.defineInRange("captchaComponentSize", 500000, 0, Integer.MAX_VALUE);
+			captchaComponentBlacklist = builder.comment("Items will fail to be captchalogued if they contain any of these item components. Captchaloguing items with lots of data can cause crashes.")
+					.define("captchaComponentBlacklist", new ArrayList<>(List.of("minecraft:container", "minecraft:block_entity_data", "create:minecart_contraption_data")));
 			sylladexDropMode = builder.comment("Determines which items from the modus that are dropped on death. \"items\": Only the items are dropped. \"cards_and_items\": Both items and cards are dropped. (So that you have at most initial_modus_size amount of cards) \"all\": Everything is dropped, even the modus.")
 					.defineEnum("dropMode", DropMode.CARDS_AND_ITEMS);
 			treeModusSetting = builder.comment("This determines if auto-balance should be forced. 'both' if the player should choose, 'on' if forced at on, and 'off' if forced at off.")

--- a/src/main/java/com/mraof/minestuck/inventory/captchalogue/CaptchaDeckHandler.java
+++ b/src/main/java/com/mraof/minestuck/inventory/captchalogue/CaptchaDeckHandler.java
@@ -18,6 +18,7 @@ import com.mraof.minestuck.util.MSAttachments;
 import com.mraof.minestuck.util.MSSoundEvents;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
+import net.minecraft.core.component.TypedDataComponent;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -28,6 +29,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.BundleContents;
+import net.minecraft.world.item.component.ItemContainerContents;
 import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.GameRules;
@@ -44,7 +47,6 @@ import org.apache.logging.log4j.Logger;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
 
 //todo this class could use some spring cleaning
 @EventBusSubscriber(modid = Minestuck.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
@@ -103,9 +105,11 @@ public final class CaptchaDeckHandler
 		if(item.getCount() > 0)
 			launchAnyItem(player, item);
 	}
+	
 	/**
 	 * Spontaneously launches items from the inventory in different directions
-	 * */
+	 *
+	 */
 	public static void launchAnyItem(Player player, ItemStack item)
 	{
 		ItemEntity entity = new ItemEntity(player.level(), player.getX(), player.getY() + 1, player.getZ(), item);
@@ -116,10 +120,11 @@ public final class CaptchaDeckHandler
 	
 	/**
 	 * Ejects all items from the inventory into a pile in front of the player
-	 * */
+	 *
+	 */
 	public static void ejectAnyItem(Player player, ItemStack item)
 	{
-		ItemEntity entity = new ItemEntity(player.level(), player.getX(), player.getY()+1, player.getZ(), item);
+		ItemEntity entity = new ItemEntity(player.level(), player.getX(), player.getY() + 1, player.getZ(), item);
 		entity.setDeltaMovement(
 				player.getViewVector(1.0F).x * 0.25 + (player.level().random.nextDouble() - 0.5) * 0.05,
 				player.getViewVector(1.0F).y * 0.25 + 0.1,
@@ -218,13 +223,46 @@ public final class CaptchaDeckHandler
 		}
 	}
 	
-	public static boolean meetsComponentSizeLimit(ItemStack stack)
+	public static boolean nestedComponentsInBlacklist(ItemStack stack)
 	{
-		AtomicLong componentDataSize = new AtomicLong(0);
+		List<? extends String> blacklist = MinestuckConfig.SERVER.captchaComponentBlacklist.get();
 		
-		stack.getComponents().forEach(component -> componentDataSize.addAndGet(component.value().toString().chars().sum()));
+		for(TypedDataComponent<?> component : stack.getComponents())
+		{
+			boolean blacklistHasComponent = blacklist.contains(component.type().toString());
+			
+			if(component.value() instanceof CardStoredItemComponent(ItemStack storedStack, boolean isGhostItem))
+			{
+				if(blacklistHasComponent && !isGhostItem && nestedComponentsInBlacklist(storedStack))
+					return true;
+			} else if(component.value() instanceof BundleContents bundle)
+			{
+				Iterable<ItemStack> items = bundle.items();
+				
+				if(items.iterator().hasNext() && blacklistHasComponent)
+					return true;
+				
+				for(ItemStack nestedItem : items)
+					if(nestedComponentsInBlacklist(nestedItem))
+						return true;
+			} else if(component.value() instanceof ItemContainerContents container)
+			{
+				Iterable<ItemStack> items = container.nonEmptyItems();
+				
+				if(items.iterator().hasNext() && blacklistHasComponent)
+					return true;
+				
+				for(ItemStack nestedItem : items)
+					if(nestedComponentsInBlacklist(nestedItem))
+						return true;
+			} else if(blacklistHasComponent)
+			{
+				return true; //else if because we want to allow the above components to pass if their storage is empty
+			}
+			
+		}
 		
-		return MinestuckConfig.SERVER.captchaComponentSize.get() >= (int) componentDataSize.get();
+		return false;
 	}
 	
 	public static void captchalogueItemInSlot(ServerPlayer player, int slotIndex, int windowId)
@@ -260,7 +298,7 @@ public final class CaptchaDeckHandler
 	
 	private static void captchalogueItem(ServerPlayer player, ItemStack stack)
 	{
-		if(!meetsComponentSizeLimit(stack))
+		if(nestedComponentsInBlacklist(stack))
 		{
 			player.displayClientMessage(Component.translatable(TOO_LARGE), false);
 			return;

--- a/src/main/java/com/mraof/minestuck/inventory/captchalogue/CaptchaDeckHandler.java
+++ b/src/main/java/com/mraof/minestuck/inventory/captchalogue/CaptchaDeckHandler.java
@@ -68,7 +68,10 @@ public final class CaptchaDeckHandler
 		}
 	}
 	
-	@SubscribeEvent
+	/**
+	 * Must occur after same event plays in {@link com.mraof.minestuck.player.Echeladder}
+	 */
+	@SubscribeEvent(priority = EventPriority.LOW)
 	private static void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event)
 	{
 		ServerPlayer player = (ServerPlayer) event.getEntity();

--- a/src/main/java/com/mraof/minestuck/player/Echeladder.java
+++ b/src/main/java/com/mraof/minestuck/player/Echeladder.java
@@ -20,6 +20,7 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.Level;
+import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.common.util.INBTSerializable;
@@ -54,7 +55,7 @@ public final class Echeladder implements INBTSerializable<CompoundTag>
 		return playerData.getData(MSAttachments.ECHELADDER);
 	}
 	
-	@SubscribeEvent
+	@SubscribeEvent(priority = EventPriority.NORMAL)
 	private static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event)
 	{
 		ServerPlayer player = (ServerPlayer) event.getEntity();


### PR DESCRIPTION
Replaces the bugged maximum data in captchalogue card mechanic with a check just for the presence of certain item Components. Any item with a container/block entity/Create mod minecart contraption will be blacklisted, but container items will still pass if the container is empty.

Also fixes an issue where players would start off with no cards against intentions